### PR TITLE
Fix bug in frequency mask

### DIFF
--- a/audiomentations/augmentations/transforms.py
+++ b/audiomentations/augmentations/transforms.py
@@ -77,12 +77,12 @@ class FrequencyMask(BasicTransform):
         nyq = 0.5 * fs
         low = lowcut / nyq
         high = highcut / nyq
-        b, a = butter(order, [low, high], btype="bandstop")
-        return b, a
+        sos = butter(order, [low, high], btype='bandstop', output='sos')
+        return sos
 
     def __butter_bandstop_filter(self, data, lowcut, highcut, fs, order=5):
-        b, a = self.__butter_bandstop(lowcut, highcut, fs, order=order)
-        y = lfilter(b, a, data).astype(np.float32)
+        sos = self.__butter_bandstop(lowcut, highcut, fs, order=order)
+        y = sosfilt(sos, data).astype(np.float32)
         return y
 
     def randomize_parameters(self, samples, sample_rate):
@@ -93,7 +93,7 @@ class FrequencyMask(BasicTransform):
                 self.max_frequency_band * sample_rate // 2,
             )
             self.parameters["freq_start"] = random.randint(
-                16, sample_rate / 2 - self.parameters["bandwidth"]
+                16, sample_rate // 2 - self.parameters["bandwidth"] - 1
             )
 
     def apply(self, samples, sample_rate):


### PR DESCRIPTION
sosfilt() function eliminates NaN values (they're now 0 instead). Also, i fixed the upper bound of the "freq_start" parameter. For example, let's take the worst case scenario ("bandwidth" and "freq_start" equal to their upper bound). That means that highcut will be equal to the Nyquist frequency.
SInce the filter's critical frequencies should be 0 < Wn <1, we are now making sure that this type of error will never occur.