### PR TITLE
save wav files as float32 format

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -32,7 +32,7 @@ def load_wav_file(sound_file_path):
 
     if sound_np.dtype != np.float32:
         assert sound_np.dtype == np.int16
-        sound_np = sound_np / 32767  # ends up roughly between -1 and 1
+        sound_np = (sound_np / 32767).astype(np.float32)  # ends up roughly between -1 and 1
 
     return sound_np
 


### PR DESCRIPTION
Some app can't open float64 format wav file, such as Window Media Player and Praat.