### PR TITLE
Add a fade option in the Shift transform

### DIFF
--- a/audiomentations/augmentations/transforms.py
+++ b/audiomentations/augmentations/transforms.py
@@ -350,7 +350,7 @@ class Shift(BaseWaveformTransform):
         max_fraction=0.5,
         rollover=True,
         fade=False,
-        fade_duration=10,
+        fade_duration=0.01,
         p=0.5,
     ):
         """
@@ -391,30 +391,67 @@ class Shift(BaseWaveformTransform):
         num_places_to_shift = self.parameters["num_places_to_shift"]
         shifted_samples = np.roll(samples, num_places_to_shift, axis=-1)
 
-        if type(self.fade_duration) == float:
-            fade_length = int(sample_rate * self.fade_duration)
-        else:
-            fade_length = self.fade_duration
-
         if not self.rollover:
             if num_places_to_shift > 0:
                 shifted_samples[..., :num_places_to_shift] = 0.0
-                if self.fade:
-
-                    # When fading in, the first sample is always 0, that's why
-                    # the fade_length - 1 below.
-
-                    shifted_samples[
-                        ...,
-                        num_places_to_shift - 1 : num_places_to_shift + fade_length - 1,
-                    ] *= np.linspace(0, 1, num=fade_length)
             elif num_places_to_shift < 0:
                 shifted_samples[..., num_places_to_shift:] = 0.0
-                if self.fade:
+
+        if self.fade:
+            fade_length = int(sample_rate * self.fade_duration)
+
+            fade_in = np.linspace(0, 1, num=fade_length)
+            fade_out = np.linspace(1, 0, num=fade_length)
+
+            if num_places_to_shift > 0:
+
+                fade_in_start = num_places_to_shift
+                fade_in_end = min(
+                    num_places_to_shift + fade_length, shifted_samples.shape[-1]
+                )
+                fade_in_length = fade_in_end - fade_in_start
+
+                shifted_samples[
+                    ...,
+                    fade_in_start:fade_in_end,
+                ] *= fade_in[:fade_in_length]
+
+                if self.rollover:
+
+                    fade_out_start = max(num_places_to_shift - fade_length, 0)
+                    fade_out_end = num_places_to_shift
+                    fade_out_length = fade_out_end - fade_out_start
+
+                    shifted_samples[..., fade_out_start:fade_out_end] *= fade_out[
+                        -fade_out_length:
+                    ]
+
+            elif num_places_to_shift < 0:
+
+                positive_num_places_to_shift = (
+                    shifted_samples.shape[-1] + num_places_to_shift
+                )
+
+                fade_out_start = max(positive_num_places_to_shift - fade_length, 0)
+                fade_out_end = positive_num_places_to_shift
+                fade_out_length = fade_out_end - fade_out_start
+
+                shifted_samples[..., fade_out_start:fade_out_end] *= fade_out[
+                    -fade_out_length:
+                ]
+
+                if self.rollover:
+                    fade_in_start = positive_num_places_to_shift
+                    fade_in_end = min(
+                        positive_num_places_to_shift + fade_length,
+                        shifted_samples.shape[-1],
+                    )
+                    fade_in_length = fade_in_end - fade_in_start
                     shifted_samples[
                         ...,
-                        num_places_to_shift - fade_length + 1 : num_places_to_shift + 1,
-                    ] *= np.linspace(1, 0, num=fade_length)
+                        fade_in_start:fade_in_end,
+                    ] *= fade_in[:fade_in_length]
+
         return shifted_samples
 
 

--- a/audiomentations/augmentations/transforms.py
+++ b/audiomentations/augmentations/transforms.py
@@ -344,7 +344,15 @@ class Shift(BaseWaveformTransform):
 
     supports_multichannel = True
 
-    def __init__(self, min_fraction=-0.5, max_fraction=0.5, rollover=True, p=0.5):
+    def __init__(
+        self,
+        min_fraction=-0.5,
+        max_fraction=0.5,
+        rollover=True,
+        fade=False,
+        fade_duration=10,
+        p=0.5,
+    ):
         """
         :param min_fraction: float, fraction of total sound length
         :param max_fraction: float, fraction of total sound length
@@ -352,14 +360,22 @@ class Shift(BaseWaveformTransform):
             are re-introduced at the last or first. When set to False, samples that roll beyond
             the first or last position are discarded. In other words, rollover=False results in
             an empty space (with zeroes).
+        :param fade: When set to True, and if rollover is False, there will be a short fade
+            in and out of the silent of duration `fade_duration`.
+        :param fade_samples: The duration of the fade. If it is an integer, then it refers to
+            samples, if float it refers to time.
         :param p:
         """
         super().__init__(p)
         assert min_fraction >= -1
         assert max_fraction <= 1
+        assert type(fade_duration) in [int, float] or not fade
+        assert fade_duration > 0 or not fade
         self.min_fraction = min_fraction
         self.max_fraction = max_fraction
         self.rollover = rollover
+        self.fade = fade
+        self.fade_duration = fade_duration
 
     def randomize_parameters(self, samples, sample_rate):
         super().randomize_parameters(samples, sample_rate)
@@ -374,11 +390,31 @@ class Shift(BaseWaveformTransform):
     def apply(self, samples, sample_rate):
         num_places_to_shift = self.parameters["num_places_to_shift"]
         shifted_samples = np.roll(samples, num_places_to_shift, axis=-1)
+
+        if type(self.fade_duration) == float:
+            fade_length = int(sample_rate * self.fade_duration)
+        else:
+            fade_length = self.fade_duration
+
         if not self.rollover:
             if num_places_to_shift > 0:
                 shifted_samples[..., :num_places_to_shift] = 0.0
+                if self.fade:
+
+                    # When fading in, the first sample is always 0, that's why
+                    # the fade_length - 1 below.
+
+                    shifted_samples[
+                        ...,
+                        num_places_to_shift - 1 : num_places_to_shift + fade_length - 1,
+                    ] *= np.linspace(0, 1, num=fade_length)
             elif num_places_to_shift < 0:
                 shifted_samples[..., num_places_to_shift:] = 0.0
+                if self.fade:
+                    shifted_samples[
+                        ...,
+                        num_places_to_shift - fade_length + 1 : num_places_to_shift + 1,
+                    ] *= np.linspace(1, 0, num=fade_length)
         return shifted_samples
 
 

--- a/audiomentations/augmentations/transforms.py
+++ b/audiomentations/augmentations/transforms.py
@@ -362,8 +362,7 @@ class Shift(BaseWaveformTransform):
             an empty space (with zeroes).
         :param fade: When set to True, and if rollover is False, there will be a short fade
             in and out of the silent of duration `fade_duration`.
-        :param fade_samples: The duration of the fade. If it is an integer, then it refers to
-            samples, if float it refers to time.
+        :param fade_duration: The duration of the fade in seconds.
         :param p:
         """
         super().__init__(p)

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -96,3 +96,52 @@ class TestShift(unittest.TestCase):
             np.array([[0.0, 0.0, 0.75, 0.5], [0.0, 0.0, 0.9, 0.5]], dtype=np.float32),
         )
         self.assertEqual(processed_samples.dtype, np.float32)
+
+    def test_shift_fade(self):
+        samples = np.array(
+            [[1.0, 2.0, 3.0, 4.0, 5.0], [-1.0, -2.0, -3.0, -4.0, -5.0]],
+            dtype=np.float32,
+        )
+        sample_rate = 4000
+
+        augment = Shift(
+            min_fraction=0.5,
+            max_fraction=0.5,
+            rollover=False,
+            fade=True,
+            fade_duration=3,
+            p=1.0,
+        )
+        processed_samples = augment(samples=samples, sample_rate=sample_rate)
+        assert_almost_equal(
+            processed_samples,
+            np.array(
+                [[0.0, 0.0, 0.5, 2.0, 3.0], [0.0, 0.0, -0.5, -2.0, -3.0]],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_shift_fade_sample_rate(self):
+        samples = np.array(
+            [[1.0, 2.0, 3.0, 4.0, 5.0], [-1.0, -2.0, -3.0, -4.0, -5.0]],
+            dtype=np.float32,
+        )
+        sample_rate = 4000
+
+        augment = Shift(
+            min_fraction=0.5,
+            max_fraction=0.5,
+            rollover=False,
+            fade=True,
+            fade_duration=0.00075,  # 0.00075 * 4000 = 3
+            p=1.0,
+        )
+        processed_samples = augment(samples=samples, sample_rate=sample_rate)
+
+        assert_almost_equal(
+            processed_samples,
+            np.array(
+                [[0.0, 0.0, 0.5, 2.0, 3.0], [0.0, 0.0, -0.5, -2.0, -3.0]],
+                dtype=np.float32,
+            ),
+        )

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -109,19 +109,20 @@ class TestShift(unittest.TestCase):
             max_fraction=0.5,
             rollover=False,
             fade=True,
-            fade_duration=3,
+            fade_duration=0.00075,  # 0.00075 * 4000 = 3
             p=1.0,
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
+
         assert_almost_equal(
             processed_samples,
             np.array(
-                [[0.0, 0.0, 0.5, 2.0, 3.0], [0.0, 0.0, -0.5, -2.0, -3.0]],
+                [[0.0, 0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 0.0, -1.0, -3.0]],
                 dtype=np.float32,
             ),
         )
 
-    def test_shift_fade_sample_rate(self):
+    def test_shift_fade_rollover(self):
         samples = np.array(
             [[1.0, 2.0, 3.0, 4.0, 5.0], [-1.0, -2.0, -3.0, -4.0, -5.0]],
             dtype=np.float32,
@@ -131,17 +132,67 @@ class TestShift(unittest.TestCase):
         augment = Shift(
             min_fraction=0.5,
             max_fraction=0.5,
-            rollover=False,
+            rollover=True,
             fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
             p=1.0,
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
-
         assert_almost_equal(
             processed_samples,
             np.array(
-                [[0.0, 0.0, 0.5, 2.0, 3.0], [0.0, 0.0, -0.5, -2.0, -3.0]],
+                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_shift_fade_rollover_2(self):
+        samples = np.array(
+            [[1.0, 2.0, 3.0, 4.0, 5.0], [-1.0, -2.0, -3.0, -4.0, -5.0]],
+            dtype=np.float32,
+        )
+        sample_rate = 4000
+
+        augment = Shift(
+            min_fraction=-0.5,
+            max_fraction=-0.5,
+            rollover=True,
+            fade=True,
+            fade_duration=0.00075,  # 0.00075 * 4000 = 3
+            p=1.0,
+        )
+        processed_samples = augment(samples=samples, sample_rate=sample_rate)
+        assert_almost_equal(
+            processed_samples,
+            np.array(
+                [[3.0, 2.0, 0.0, 0.0, 1.0], [-3.0, -2.0, 0.0, -0.0, -1.0]],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_shift_fade_rollover_3(self):
+        samples = np.array(
+            [[1.0, 2.0, 3.0, 4.0, 5.0], [-1.0, -2.0, -3.0, -4.0, -5.0]],
+            dtype=np.float32,
+        )
+        sample_rate = 4000
+
+        augment = Shift(
+            min_fraction=-0.5,
+            max_fraction=-0.5,
+            rollover=True,
+            fade=True,
+            fade_duration=1.0,
+            p=1.0,
+        )
+        processed_samples = augment(samples=samples, sample_rate=sample_rate)
+        assert_almost_equal(
+            processed_samples,
+            np.array(
+                [
+                    [0.0015004, 0.0010003, 0.0, 0.0, 0.0005001],
+                    [-0.0015004, -0.0010003, -0.0, -0.0, -0.0005001],
+                ],
                 dtype=np.float32,
             ),
         )


### PR DESCRIPTION
* Add a `fade` and a `fade_duration` parameter in
`audiomentations.augmentations.transforms.Shift`
* Add the corresponding tests

There are cases where a shift transform without rollover would introduce abrupt changes from zero to non-zero samples leading to transients such as ones in the following image:

![image](https://user-images.githubusercontent.com/349290/109805251-e279c080-7c2b-11eb-939f-6df712b71be3.png)

For this reason I have made the following pull request which adds a `fade: bool` and a `fade_duration` `int` or `float` to `Shift.__init__`. When `fade_duration` is an int the fade is in samples while when its a `float` it is a time duration.