### PR TITLE
Fix a bug in AddImpulseResponse when samples = zero signal.

### DIFF
--- a/audiomentations/augmentations/transforms.py
+++ b/audiomentations/augmentations/transforms.py
@@ -73,8 +73,9 @@ class AddImpulseResponse(BaseWaveformTransform):
             )
         signal_ir = convolve(samples, ir)
         max_value = max(np.amax(signal_ir), -np.amin(signal_ir))
-        scale = 0.5 / max_value
-        signal_ir *= scale
+        if max_value > 0.0:
+            scale = 0.5 / max_value
+            signal_ir *= scale
         if self.leave_length_unchanged:
             signal_ir = signal_ir[..., : samples.shape[-1]]
         return signal_ir


### PR DESCRIPTION
Zero signal will yield max_value to be 0, hence divide by zero error will occur. This commit avoids the bug.