### PR TITLE
support np.float64 in load_wav_file()

### DIFF
--- a/audiomentations/core/audio_loading_utils.py
+++ b/audiomentations/core/audio_loading_utils.py
@@ -81,6 +81,9 @@ def load_wav_file(file_path, sample_rate, mono=True, resample_type="kaiser_best"
 
     actual_sample_rate, samples = wavfile.read(file_path)
 
+    if samples.dtype == np.float64:
+        samples = samples.astype(np.float32)
+        
     if samples.dtype != np.float32:
         if samples.dtype == np.int16:
             samples = np.true_divide(


### PR DESCRIPTION
This PR fixes #101 

- convert np.float64 to np.float32 in load_wav_file()