### PR TITLE
Changed the function calculate_rms_without_noise so that it can tackle very short files

### DIFF
--- a/audiomentations/core/utils.py
+++ b/audiomentations/core/utils.py
@@ -42,7 +42,12 @@ def calculate_rms_without_silence(samples, sample_rate):
     This function returns the rms of a given noise whose silent periods have been removed. This ensures
     that the rms of the noise is not underestimated. Is most useful for short non-stationary noises.
     """
+
     window = int(0.025 * sample_rate)
+
+    if len(samples) < window:
+        return calculate_rms(samples)
+
     rms_all_windows = np.zeros(len(samples) // window)
     current_time = 0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,3 +50,7 @@ class TestUtils(unittest.TestCase):
         rms_after = calculate_rms_without_silence(samples_in, sample_rate)
         self.assertGreater(rms_after, rms_before)
         self.assertAlmostEqual(rms_after, 0.4)
+
+        # Check that the function works if the input is shorter than a window (25 ms)
+        rms_short = calculate_rms_without_silence(samples_in[0:int(0.015*sample_rate)], sample_rate)
+        self.assertAlmostEqual(rms_short, 0.4)


### PR DESCRIPTION
Before this change, an error was sometimes raised when using the transform AddShortNoises. It cames from the fact that if noises were added very shortly before the end of an audio file, it was not possible to calculate their rms because they were shorter than the window used in calculate_rms_without_noise. This bug has been fixed.