### PR TITLE
Implement OneOf. Refactor compose classes. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Note: `ffmpeg` can be installed via e.g. conda or from [the official ffmpeg down
 from audiomentations import Compose, AddGaussianNoise, TimeStretch, PitchShift, Shift
 import numpy as np
 
-SAMPLE_RATE = 16000
-
 augment = Compose([
     AddGaussianNoise(min_amplitude=0.001, max_amplitude=0.015, p=0.5),
     TimeStretch(min_rate=0.8, max_rate=1.25, p=0.5),
@@ -52,7 +50,7 @@ augment = Compose([
 samples = np.random.uniform(low=-0.2, high=0.2, size=(32000,)).astype(np.float32)
 
 # Augment/transform/perturb the audio data
-augmented_samples = augment(samples=samples, sample_rate=SAMPLE_RATE)
+augmented_samples = augment(samples=samples, sample_rate=16000)
 ```
 
 Go to [audiomentations/augmentations/transforms.py](https://github.com/iver56/audiomentations/blob/master/audiomentations/augmentations/transforms.py) to see the waveform transforms you can apply, and what arguments they have.

--- a/audiomentations/__init__.py
+++ b/audiomentations/__init__.py
@@ -26,6 +26,6 @@ from .augmentations.transforms import (
     TimeStretch,
     Trim,
 )
-from .core.composition import Compose, SpecCompose
+from .core.composition import Compose, SpecCompose, OneOf
 
 __version__ = "0.19.0"

--- a/audiomentations/core/composition.py
+++ b/audiomentations/core/composition.py
@@ -113,8 +113,8 @@ class OneOf(BaseCompose):
 
     ```
     augment = OneOf([
-        TimeStretch(min_rate=0.8, max_rate=1.25, p=0.5),
-        PitchShift(min_semitones=-4, max_semitones=4, p=0.5),
+        TimeStretch(min_rate=0.8, max_rate=1.25, p=1.0),
+        PitchShift(min_semitones=-4, max_semitones=4, p=1.0),
     ])
 
     # Generate 2 seconds of dummy audio for the sake of example
@@ -122,6 +122,8 @@ class OneOf(BaseCompose):
 
     # Augment/transform/perturb the audio data
     augmented_samples = augment(samples=samples, sample_rate=16000)
+
+    # Result: The audio was either time-stretched or pitch-shifted, but not both
     ```
     """
 

--- a/audiomentations/core/composition.py
+++ b/audiomentations/core/composition.py
@@ -22,6 +22,8 @@ class BaseCompose:
         """
         apply_to_children = kwargs.get("apply_to_children", True)
         if apply_to_children:
+            if "apply_to_children" in kwargs:
+                del kwargs["apply_to_children"]
             for transform in self.transforms:
                 transform.randomize_parameters(*args, **kwargs)
 
@@ -140,9 +142,12 @@ class OneOf(BaseCompose):
 
     def __call__(self, *args, **kwargs):
         if not self.are_parameters_frozen:
-            self.randomize_parameters(apply_to_children=False)
+            kwargs["apply_to_children"] = False
+            self.randomize_parameters(*args, **kwargs)
 
         if self.should_apply:
+            if "apply_to_children" in kwargs:
+                del kwargs["apply_to_children"]
             return self.transforms[self.transform_index](*args, **kwargs)
 
         if "samples" in kwargs:

--- a/audiomentations/core/composition.py
+++ b/audiomentations/core/composition.py
@@ -2,10 +2,11 @@ import random
 
 
 class BaseCompose:
-    def __init__(self, transforms, p=1.0, shuffle=False):
+    def __init__(self, transforms, p: float = 1.0, shuffle: bool = False):
         self.transforms = transforms
         self.p = p
         self.shuffle = shuffle
+        self.are_parameters_frozen = False
 
         name_list = []
         for transform in self.transforms:
@@ -19,43 +20,70 @@ class BaseCompose:
         """
         Randomize and define parameters of every transform in composition.
         """
-        raise NotImplementedError
+        apply_to_children = kwargs.get("apply_to_children", True)
+        if apply_to_children:
+            for transform in self.transforms:
+                transform.randomize_parameters(*args, **kwargs)
 
-    def freeze_parameters(self):
+    def freeze_parameters(self, apply_to_children=True):
         """
         Mark all parameters as frozen, i.e. do not randomize them for each call. This can be
         useful if you want to apply an effect chain with the exact same parameters to multiple
         sounds.
         """
-        for transform in self.transforms:
-            transform.freeze_parameters()
+        self.are_parameters_frozen = True
+        if apply_to_children:
+            for transform in self.transforms:
+                transform.freeze_parameters()
 
-    def unfreeze_parameters(self):
+    def unfreeze_parameters(self, apply_to_children=True):
         """
         Unmark all parameters as frozen, i.e. let them be randomized for each call.
         """
-        for transform in self.transforms:
-            transform.unfreeze_parameters()
+        self.are_parameters_frozen = False
+        if apply_to_children:
+            for transform in self.transforms:
+                transform.unfreeze_parameters()
 
 
 class Compose(BaseCompose):
-    # TODO: Name can change to WaveformCompose
+    """
+    Compose applies the given sequence of transforms when called,
+    optionally shuffling the sequence for every call.
+
+    Example usage:
+
+    ```
+    augment = Compose([
+        AddGaussianNoise(min_amplitude=0.001, max_amplitude=0.015, p=0.5),
+        TimeStretch(min_rate=0.8, max_rate=1.25, p=0.5),
+        PitchShift(min_semitones=-4, max_semitones=4, p=0.5),
+        Shift(min_fraction=-0.5, max_fraction=0.5, p=0.5),
+    ])
+
+    # Generate 2 seconds of dummy audio for the sake of example
+    samples = np.random.uniform(low=-0.2, high=0.2, size=(32000,)).astype(np.float32)
+
+    # Augment/transform/perturb the audio data
+    augmented_samples = augment(samples=samples, sample_rate=16000)
+    ```
+    """
+
     def __init__(self, transforms, p=1.0, shuffle=False):
-        super(Compose, self).__init__(transforms, p, shuffle)
+        super().__init__(transforms, p, shuffle)
 
     def __call__(self, samples, sample_rate):
         transforms = self.transforms.copy()
-        if random.random() < self.p:
+        should_apply = random.random() < self.p
+        # TODO: Adhere to self.are_parameters_frozen
+        # https://github.com/iver56/audiomentations/issues/135
+        if should_apply:
             if self.shuffle:
                 random.shuffle(transforms)
             for transform in transforms:
                 samples = transform(samples, sample_rate)
 
         return samples
-
-    def randomize_parameters(self, samples, sample_rate):
-        for transform in self.transforms:
-            transform.randomize_parameters(samples, sample_rate)
 
 
 class SpecCompose(BaseCompose):
@@ -64,7 +92,10 @@ class SpecCompose(BaseCompose):
 
     def __call__(self, magnitude_spectrogram):
         transforms = self.transforms.copy()
-        if random.random() < self.p:
+        should_apply = random.random() < self.p
+        # TODO: Adhere to self.are_parameters_frozen
+        # https://github.com/iver56/audiomentations/issues/135
+        if should_apply:
             if self.shuffle:
                 random.shuffle(transforms)
             for transform in transforms:
@@ -72,6 +103,49 @@ class SpecCompose(BaseCompose):
 
         return magnitude_spectrogram
 
-    def randomize_parameters(self, magnitude_spectrogram):
-        for transform in self.transforms:
-            transform.randomize_parameters(magnitude_spectrogram)
+
+class OneOf(BaseCompose):
+    """
+    OneOf randomly picks one of the given transforms when called, and applies that
+    transform.
+
+    Example usage:
+
+    ```
+    augment = OneOf([
+        TimeStretch(min_rate=0.8, max_rate=1.25, p=0.5),
+        PitchShift(min_semitones=-4, max_semitones=4, p=0.5),
+    ])
+
+    # Generate 2 seconds of dummy audio for the sake of example
+    samples = np.random.uniform(low=-0.2, high=0.2, size=(32000,)).astype(np.float32)
+
+    # Augment/transform/perturb the audio data
+    augmented_samples = augment(samples=samples, sample_rate=16000)
+    ```
+    """
+
+    def __init__(self, transforms, p: float = 1.0):
+        super().__init__(transforms, p)
+        self.transform_index = 0
+        self.should_apply = True
+
+    def randomize_parameters(self, *args, **kwargs):
+        super().randomize_parameters(*args, **kwargs)
+        self.should_apply = random.random() < self.p
+        if self.should_apply:
+            self.transform_index = random.randint(0, len(self.transforms) - 1)
+
+    def __call__(self, *args, **kwargs):
+        if not self.are_parameters_frozen:
+            self.randomize_parameters(apply_to_children=False)
+
+        if self.should_apply:
+            return self.transforms[self.transform_index](*args, **kwargs)
+
+        if "samples" in kwargs:
+            return kwargs["samples"]
+        elif "magnitude_spectrogram" in kwargs:
+            return kwargs["magnitude_spectrogram"]
+        else:
+            return args[0]

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -1,0 +1,100 @@
+import os
+import unittest
+
+import numpy as np
+from audiomentations import Gain
+from numpy.testing import assert_array_equal
+
+from audiomentations.augmentations.transforms import (
+    ClippingDistortion,
+    AddBackgroundNoise,
+    FrequencyMask,
+    TimeMask,
+    Shift,
+    PolarityInversion,
+)
+from audiomentations import OneOf
+from demo.demo import DEMO_DIR
+
+
+class TestOneOf(unittest.TestCase):
+    def test_exactly_one_transform_applied(self):
+        samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
+        sample_rate = 44100
+
+        for _ in range(30):
+            augmenter = OneOf(
+                [
+                    Gain(min_gain_in_db=-12, max_gain_in_db=-6, p=1.0),
+                    PolarityInversion(p=1.0),
+                ]
+            )
+            perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+
+            was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
+            was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+
+            num_transforms_applied = sum(
+                [
+                    1 if was_gain_applied else 0,
+                    1 if was_polarity_inversion_applied else 0,
+                ]
+            )
+            assert num_transforms_applied == 1
+
+    def test_freeze_and_unfreeze_parameters(self):
+        samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
+        sample_rate = 44100
+
+        for _ in range(30):
+            augmenter = OneOf(
+                [
+                    Gain(p=1.0),
+                    PolarityInversion(p=1.0),
+                ]
+            )
+            perturbed_samples1 = augmenter(samples=samples, sample_rate=sample_rate)
+            augmenter.freeze_parameters()
+            for transform in augmenter.transforms:
+                self.assertTrue(transform.are_parameters_frozen)
+            perturbed_samples2 = augmenter(samples=samples, sample_rate=sample_rate)
+
+            assert_array_equal(perturbed_samples1, perturbed_samples2)
+
+            augmenter.unfreeze_parameters()
+            for transform in augmenter.transforms:
+                self.assertFalse(transform.are_parameters_frozen)
+
+    def test_randomize_parameters_and_apply(self):
+        samples = 1.0 / np.arange(1, 21, dtype=np.float32)
+        sample_rate = 44100
+
+        augmenter = OneOf(
+            [
+                AddBackgroundNoise(
+                    sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+                    min_snr_in_db=15,
+                    max_snr_in_db=35,
+                    p=1.0,
+                ),
+                ClippingDistortion(p=1.0),
+                FrequencyMask(min_frequency_band=0.3, max_frequency_band=0.5, p=1.0),
+                TimeMask(min_band_part=0.2, max_band_part=0.5, p=1.0),
+                Shift(min_fraction=0.5, max_fraction=0.5, p=1.0),
+            ]
+        )
+        augmenter.freeze_parameters()
+        augmenter.randomize_parameters(samples=samples, sample_rate=sample_rate)
+
+        parameters = [transform.parameters for transform in augmenter.transforms]
+
+        perturbed_samples1 = augmenter(samples=samples, sample_rate=sample_rate)
+        perturbed_samples2 = augmenter(samples=samples, sample_rate=sample_rate)
+
+        assert_array_equal(perturbed_samples1, perturbed_samples2)
+
+        augmenter.unfreeze_parameters()
+
+        for transform_parameters, transform in zip(parameters, augmenter.transforms):
+            assert transform_parameters == transform.parameters
+            assert not transform.are_parameters_frozen


### PR DESCRIPTION
Also add `apply_to_children` argument in some methods in BaseCompose. It defaults to `True`, so the change is backwards compatible.

#61 