### PR TITLE
Added option in addshortnoise

### DIFF
--- a/audiomentations/augmentations/add_short_noises.py
+++ b/audiomentations/augmentations/add_short_noises.py
@@ -54,13 +54,13 @@ class AddShortNoises(BaseWaveformTransform):
             sounds/noises will be louder.
         :param min_time_between_sounds: Minimum pause time between the added sounds/noises
         :param max_time_between_sounds: Maximum pause time between the added sounds/noises
-        :param noise_rms: To choose in ["relative", "absolute", "relative_to_whole_file"].
+        :param noise_rms: To choose in ["relative", "absolute", "relative_to_whole_input"].
             Defines how the noises will be added to the audio input.
             "relative": the rms value of the added noise will be proportional to the rms value of
             the input sound calculated only for the samples where the noise is added.
             "absolute": the added noises will have a rms independent of the rms of the input audio
             file.
-            "relative_to_whole_file": the rms of the added noises will be
+            "relative_to_whole_input": the rms of the added noises will be
             proportional to the rms of the input sound calculated for the whole file.
         :param min_absolute_noise_rms_db: Is only used if noise_rms is set to "absolute". It is
             the minimum rms value in dB that the added noise can take. The lower the rms is, the
@@ -114,7 +114,7 @@ class AddShortNoises(BaseWaveformTransform):
         assert min_fade_out_time <= max_fade_out_time
         assert min_absolute_noise_rms_db <= max_absolute_noise_rms_db < 0
         assert type(include_silence_in_noise_rms_estimation) == bool
-        assert noise_rms in ["relative", "absolute", "relative_to_whole_file"]
+        assert noise_rms in ["relative", "absolute", "relative_to_whole_input"]
 
         self.min_snr_in_db = min_snr_in_db
         self.max_snr_in_db = max_snr_in_db
@@ -293,7 +293,7 @@ class AddShortNoises(BaseWaveformTransform):
                 ]
                 end_sample_index = num_samples
 
-            if self.noise_rms == "relative_to_whole_file":
+            if self.noise_rms == "relative_to_whole_input":
                 clean_rms = calculate_rms(samples)
             else:
                 clean_rms = calculate_rms(samples[start_sample_index:end_sample_index])
@@ -304,7 +304,7 @@ class AddShortNoises(BaseWaveformTransform):
                 noise_rms = calculate_rms_without_silence(noise_samples, sample_rate)
 
             if noise_rms > 0:
-                if self.noise_rms in ["relative", "relative_to_whole_file"]:
+                if self.noise_rms in ["relative", "relative_to_whole_input"]:
 
                     desired_noise_rms = calculate_desired_noise_rms(
                         clean_rms, sound_params["snr_in_db"]

--- a/audiomentations/augmentations/add_short_noises.py
+++ b/audiomentations/augmentations/add_short_noises.py
@@ -54,10 +54,14 @@ class AddShortNoises(BaseWaveformTransform):
             sounds/noises will be louder.
         :param min_time_between_sounds: Minimum pause time between the added sounds/noises
         :param max_time_between_sounds: Maximum pause time between the added sounds/noises
-        :param noise_rms: Defines how the noises will be added to the audio input. If the chosen
-            option is "relative", the rms of the added noise will be proportional to the rms of
-            the input sound. If the chosen option is "absolute", the added noises will have
-            a rms independent of the rms of the input audio file.
+        :param noise_rms: To choose in ["relative", "absolute", "relative_to_whole_file"].
+            Defines how the noises will be added to the audio input.
+            "relative": the rms value of the added noise will be proportional to the rms value of
+            the input sound calculated only for the samples where the noise is added.
+            "absolute": the added noises will have a rms independent of the rms of the input audio
+            file.
+            "relative_to_whole_file": the rms of the added noises will be
+            proportional to the rms of the input sound calculated for the whole file.
         :param min_absolute_noise_rms_db: Is only used if noise_rms is set to "absolute". It is
             the minimum rms value in dB that the added noise can take. The lower the rms is, the
             lower will the added sound be.
@@ -110,6 +114,7 @@ class AddShortNoises(BaseWaveformTransform):
         assert min_fade_out_time <= max_fade_out_time
         assert min_absolute_noise_rms_db <= max_absolute_noise_rms_db < 0
         assert type(include_silence_in_noise_rms_estimation) == bool
+        assert noise_rms in ["relative", "absolute", "relative_to_whole_file"]
 
         self.min_snr_in_db = min_snr_in_db
         self.max_snr_in_db = max_snr_in_db
@@ -288,7 +293,10 @@ class AddShortNoises(BaseWaveformTransform):
                 ]
                 end_sample_index = num_samples
 
-            clean_rms = calculate_rms(samples[start_sample_index:end_sample_index])
+            if self.noise_rms == "relative_to_whole_file":
+                clean_rms = calculate_rms(samples)
+            else:
+                clean_rms = calculate_rms(samples[start_sample_index:end_sample_index])
 
             if self.include_silence_in_noise_rms_estimation:
                 noise_rms = calculate_rms(noise_samples)
@@ -296,7 +304,7 @@ class AddShortNoises(BaseWaveformTransform):
                 noise_rms = calculate_rms_without_silence(noise_samples, sample_rate)
 
             if noise_rms > 0:
-                if self.noise_rms == "relative":
+                if self.noise_rms in ["relative", "relative_to_whole_file"]:
 
                     desired_noise_rms = calculate_desired_noise_rms(
                         clean_rms, sound_params["snr_in_db"]

--- a/tests/test_add_short_noises.py
+++ b/tests/test_add_short_noises.py
@@ -184,7 +184,7 @@ class TestAddShortNoises(unittest.TestCase):
         unpickled = pickle.loads(pickled)
         self.assertEqual(transform.sound_file_paths, unpickled.sound_file_paths)
 
-    def test_absolute_parameter(self):
+    def test_noise_rms_parameter(self):
         np.random.seed(80085)
         random.seed("ling")
         sample_rate = 44100
@@ -192,7 +192,21 @@ class TestAddShortNoises(unittest.TestCase):
             np.float32
         )
         rms_before = calculate_rms(samples)
-        augmenter = Compose(
+        augmenter_relative_to_whole_file = Compose(
+            [
+                AddShortNoises(
+                    sounds_path=os.path.join(DEMO_DIR, "short_noises"),
+                    min_time_between_sounds=2.0,
+                    max_time_between_sounds=8.0,
+                    min_snr_in_db=5,
+                    max_snr_in_db=5,
+                    noise_rms="relative_to_whole_file",
+                    p=1.0,
+                )
+            ]
+        )
+
+        augmenter_absolute = Compose(
             [
                 AddShortNoises(
                     sounds_path=os.path.join(DEMO_DIR, "short_noises"),
@@ -203,12 +217,15 @@ class TestAddShortNoises(unittest.TestCase):
                 )
             ]
         )
-        samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        self.assertEqual(samples_out.dtype, np.float32)
-        self.assertEqual(samples_out.shape, samples.shape)
 
-        rms_after = calculate_rms(samples_out)
-        self.assertGreater(rms_after, rms_before)
+        samples_out_absolute = augmenter_absolute(samples=samples, sample_rate=sample_rate)
+        samples_out_relative_to_whole_file = augmenter_relative_to_whole_file(samples=samples, sample_rate=sample_rate)
+        self.assertEqual(samples_out_absolute.dtype, np.float32)
+        self.assertEqual(samples_out_absolute.shape, samples.shape)
+        rms_after_relative_to_whole_path = calculate_rms(samples_out_relative_to_whole_file)
+        rms_after_absolute = calculate_rms(samples_out_absolute)
+        self.assertGreater(rms_after_absolute, rms_before)
+        self.assertGreater(rms_after_relative_to_whole_path, rms_before)
 
     def test_include_silence_in_noise_rms_calculation(self):
         np.random.seed(420)

--- a/tests/test_add_short_noises.py
+++ b/tests/test_add_short_noises.py
@@ -192,7 +192,7 @@ class TestAddShortNoises(unittest.TestCase):
             np.float32
         )
         rms_before = calculate_rms(samples)
-        augmenter_relative_to_whole_file = Compose(
+        augmenter_relative_to_whole_input = Compose(
             [
                 AddShortNoises(
                     sounds_path=os.path.join(DEMO_DIR, "short_noises"),
@@ -200,7 +200,7 @@ class TestAddShortNoises(unittest.TestCase):
                     max_time_between_sounds=8.0,
                     min_snr_in_db=5,
                     max_snr_in_db=5,
-                    noise_rms="relative_to_whole_file",
+                    noise_rms="relative_to_whole_input",
                     p=1.0,
                 )
             ]
@@ -219,10 +219,10 @@ class TestAddShortNoises(unittest.TestCase):
         )
 
         samples_out_absolute = augmenter_absolute(samples=samples, sample_rate=sample_rate)
-        samples_out_relative_to_whole_file = augmenter_relative_to_whole_file(samples=samples, sample_rate=sample_rate)
+        samples_out_relative_to_whole_input = augmenter_relative_to_whole_input(samples=samples, sample_rate=sample_rate)
         self.assertEqual(samples_out_absolute.dtype, np.float32)
         self.assertEqual(samples_out_absolute.shape, samples.shape)
-        rms_after_relative_to_whole_path = calculate_rms(samples_out_relative_to_whole_file)
+        rms_after_relative_to_whole_path = calculate_rms(samples_out_relative_to_whole_input)
         rms_after_absolute = calculate_rms(samples_out_absolute)
         self.assertGreater(rms_after_absolute, rms_before)
         self.assertGreater(rms_after_relative_to_whole_path, rms_before)


### PR DESCRIPTION
Modified AddShortNoises transform. Added the option "relatively_to_whole_file" in the parameter "noise_rms". so that short noises can be added relatively to the power of the whole clean file and not just to the power of the samples where they are inserted (default behaviour). This has been implemented to address some shortcomings of the default option "relative", like to be able to add short noises even in relatively silent periods.