### PR TITLE
Tweak Padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ Apply a constant amount of gain, so that highest signal level present in the sou
 0 dBFS, i.e. the loudest level allowed if all samples must be between -1 and 1. Also known
 as peak normalization.
 
+## `Padding`
+
+_To be released in v0.23.0_
+
+Apply padding to the audio signal - take a fraction of the end or the start of the
+audio and replace that part with padding. This can be useful for preparing ML models
+with constant input length for padded inputs.
+
 ## `PeakingFilter`
 
 _Added in v0.21.0_

--- a/audiomentations/augmentations/padding.py
+++ b/audiomentations/augmentations/padding.py
@@ -8,8 +8,8 @@ from audiomentations.core.transforms_interface import BaseWaveformTransform
 class Padding(BaseWaveformTransform):
     """
     Apply padding to the audio signal - take a fraction of the end or the start of the
-    audio and replace that part as padding. This can be useful for preparing models with
-    constant input length for padded inputs.
+    audio and replace that part with padding. This can be useful for preparing ML models
+    with constant input length for padded inputs.
     """
 
     supports_multichannel = True

--- a/audiomentations/core/transforms_interface.py
+++ b/audiomentations/core/transforms_interface.py
@@ -55,7 +55,7 @@ class BaseWaveformTransform(BaseTransform):
     def __call__(self, samples: np.ndarray, sample_rate: int) -> np.ndarray:
         if samples.dtype == np.float64:
             warnings.warn(
-                "Warning: input samples have np.float64 dtype. Converting to np.float32..."
+                "Warning: input samples dtype is np.float64. Converting to np.float32"
             )
             samples = np.float32(samples)
         if not self.are_parameters_frozen:

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -146,7 +146,9 @@ if __name__ == "__main__":
         },
         {
             "instance": ApplyImpulseResponse(
-                p=1.0, ir_path=os.path.join(DEMO_DIR, "ir"), leave_length_unchanged=False
+                p=1.0,
+                ir_path=os.path.join(DEMO_DIR, "ir"),
+                leave_length_unchanged=False,
             ),
             "num_runs": 1,
             "name": "ApplyImpulseResponseWithTail",
@@ -234,16 +236,29 @@ if __name__ == "__main__":
         },
         {"instance": Normalize(p=1.0), "num_runs": 1},
         {
-            "instance": Padding(mode="constant", p=1.0),
+            "instance": Padding(mode="silence", pad_section="end", p=1.0),
             "num_runs": 5,
-            "name": "PaddingConstant",
+            "name": "PaddingSilenceEnd",
         },
-        {"instance": Padding(mode="edge", p=1.0), "num_runs": 5, "name": "PaddingEdge"},
-        {"instance": Padding(mode="wrap", p=1.0), "num_runs": 5, "name": "PaddingWrap"},
         {
-            "instance": Padding(mode="reflect", p=1.0),
+            "instance": Padding(mode="wrap", pad_section="end", p=1.0),
             "num_runs": 5,
-            "name": "PaddingReflect",
+            "name": "PaddingWrapEnd",
+        },
+        {
+            "instance": Padding(mode="reflect", pad_section="end", p=1.0),
+            "num_runs": 5,
+            "name": "PaddingReflectEnd",
+        },
+        {
+            "instance": Padding(mode="silence", pad_section="start", p=1.0),
+            "num_runs": 5,
+            "name": "PaddingSilenceStart",
+        },
+        {
+            "instance": Padding(mode="wrap", pad_section="start", p=1.0),
+            "num_runs": 5,
+            "name": "PaddingWrapStart",
         },
         {"instance": PeakingFilter(p=1.0), "num_runs": 5},
         {"instance": PolarityInversion(p=1.0), "num_runs": 1},

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -35,8 +35,9 @@ class TestPadding:
         assert samples.dtype == np.float32
         assert samples.shape == input_shape
 
+    @pytest.mark.parametrize("mode", ["silence", "wrap", "reflect"])
     @pytest.mark.parametrize("pad_section", ["start", "end"])
-    def test_padding_multichannel(self, pad_section):
+    def test_padding_multichannel(self, mode, pad_section):
         samples = np.array(
             [
                 [0.9, 0.5, -0.25, -0.125, 0.0],
@@ -48,7 +49,7 @@ class TestPadding:
         sample_rate = 16000
         input_shape = samples.shape
 
-        augmenter = Padding(pad_section=pad_section, p=1.0)
+        augmenter = Padding(mode=mode, pad_section=pad_section, p=1.0)
         samples = augmenter(samples=samples, sample_rate=sample_rate)
 
         assert samples.dtype == np.float32

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,60 +1,107 @@
-import unittest
+import random
 
 import numpy as np
-from numpy.testing import assert_array_equal
+import pytest
+from numpy import array_equal
 
-from audiomentations import Padding, Compose
+from audiomentations import Padding
 
 
-class TestPadding(unittest.TestCase):
-    def test_padding_constant(self):
-        samples = np.array([0.5, 0.6, -0.2, 0.0], dtype=np.float32)
+class TestPadding:
+    @pytest.mark.parametrize("mode", ["silence", "wrap", "reflect"])
+    @pytest.mark.parametrize("pad_section", ["start", "end"])
+    def test_padding_mono_1d(self, mode, pad_section):
+        random.seed(546)
+        samples = np.array([0.5, 0.6, -0.2, 1.0], dtype=np.float32)
         sample_rate = 16000
-        orig_len = len(samples)
-        augmenter = Compose([Padding(mode='constant', p=1.0)])
+        input_shape = samples.shape
+        augmenter = Padding(mode=mode, pad_section=pad_section, p=1.0)
         samples = augmenter(samples=samples, sample_rate=sample_rate)
 
-        self.assertEqual(samples.dtype, np.float32)
-        self.assertEqual(len(samples), orig_len)
+        assert samples.dtype == np.float32
+        assert samples.shape == input_shape
 
-    def test_padding_edge(self):
-        samples = np.array([0.5, 0.6, -0.8, 0.0], dtype=np.float32)
-        sample_rate = 16000
-        orig_len = len(samples)
-        augmenter = Compose([Padding(mode='edge', p=1.0)])
-        samples = augmenter(samples=samples, sample_rate=sample_rate)
-
-        self.assertEqual(samples.dtype, np.float32)
-        self.assertEqual(len(samples), orig_len)
-
-    def test_padding_wrap(self):
-        samples = np.array([0.5, 0.6, -0.8, 0.0], dtype=np.float32)
-        sample_rate = 16000
-        orig_len = len(samples)
-        augmenter = Compose([Padding(mode='wrap', p=1.0)])
-        samples = augmenter(samples=samples, sample_rate=sample_rate)
-
-        self.assertEqual(samples.dtype, np.float32)
-        self.assertEqual(len(samples), orig_len)
-        
-    def test_padding_reflect(self):
-        samples = np.array([0.5, 0.6, -0.8, 0.0], dtype=np.float32)
-        sample_rate = 16000
-        orig_len = len(samples)
-        augmenter = Compose([Padding(mode='reflect', p=1.0)])
-        samples = augmenter(samples=samples, sample_rate=sample_rate)
-
-        self.assertEqual(samples.dtype, np.float32)
-        self.assertEqual(len(samples), orig_len)
-
-    def test_padding_constant_multichannel(self):
+    def test_padding_mono_2d(self):
         samples = np.array(
-            [[0.9, 0.5, -0.25, -0.125, 0.0], [0.95, 0.5, -0.25, -0.125, 0.0]],
+            [[0.9, 0.5, -0.25, -0.125, 0.0]],
             dtype=np.float32,
         )
         sample_rate = 16000
+        input_shape = samples.shape
 
-        augmenter = Compose([Padding(mode='constant', p=1.0)])
+        augmenter = Padding(p=1.0)
         samples = augmenter(samples=samples, sample_rate=sample_rate)
 
-        self.assertEqual(samples.dtype, np.float32)
+        assert samples.dtype == np.float32
+        assert samples.shape == input_shape
+
+    @pytest.mark.parametrize("pad_section", ["start", "end"])
+    def test_padding_multichannel(self, pad_section):
+        samples = np.array(
+            [
+                [0.9, 0.5, -0.25, -0.125, 0.0],
+                [0.95, 0.5, -0.25, -0.125, 0.0],
+                [0.95, 0.5, -0.25, -0.125, 0.0],
+            ],
+            dtype=np.float32,
+        )
+        sample_rate = 16000
+        input_shape = samples.shape
+
+        augmenter = Padding(pad_section=pad_section, p=1.0)
+        samples = augmenter(samples=samples, sample_rate=sample_rate)
+
+        assert samples.dtype == np.float32
+        assert samples.shape == input_shape
+
+    def test_padding_reflect_start(self):
+        samples = np.array([0.5, 0.6, 0.9, -0.2, 1.0], dtype=np.float32)
+        sample_rate = 16000
+        augmenter = Padding(
+            mode="reflect",
+            pad_section="start",
+            min_fraction=0.4,
+            max_fraction=0.4,
+            p=1.0,
+        )
+        samples = augmenter(samples=samples, sample_rate=sample_rate)
+        assert array_equal(
+            samples, np.array([1.0, -0.2, 0.9, -0.2, 1.0], dtype=np.float32)
+        )
+
+    def test_padding_reflect_end(self):
+        samples = np.array([0.5, 0.6, 0.9, -0.2, 1.0], dtype=np.float32)
+        sample_rate = 16000
+        augmenter = Padding(
+            mode="reflect",
+            pad_section="end",
+            min_fraction=0.4,
+            max_fraction=0.4,
+            p=1.0,
+        )
+        samples = augmenter(samples=samples, sample_rate=sample_rate)
+        assert array_equal(
+            samples, np.array([0.5, 0.6, 0.9, 0.6, 0.5], dtype=np.float32)
+        )
+
+    def test_pad_nothing(self):
+        samples = np.array([0.5, 0.6, -0.2, 0.1], dtype=np.float32)
+        sample_rate = 16000
+        input_shape = samples.shape
+        augmenter = Padding(min_fraction=0.0, max_fraction=0.0, p=1.0)
+        samples = augmenter(samples=samples, sample_rate=sample_rate)
+
+        assert array_equal(samples, np.array([0.5, 0.6, -0.2, 0.1], dtype=np.float32))
+        assert samples.dtype == np.float32
+        assert samples.shape == input_shape
+
+    def test_pad_everything(self):
+        samples = np.array([0.5, 0.6, -0.2, 0.7], dtype=np.float32)
+        sample_rate = 16000
+        input_shape = samples.shape
+        augmenter = Padding(min_fraction=1.0, max_fraction=1.0, p=1.0)
+        samples = augmenter(samples=samples, sample_rate=sample_rate)
+
+        assert not np.any(samples)
+        assert samples.dtype == np.float32
+        assert samples.shape == input_shape

--- a/tests/test_some_of.py
+++ b/tests/test_some_of.py
@@ -1,6 +1,8 @@
 import os
+import random
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from audiomentations import (
@@ -19,44 +21,104 @@ from demo.demo import DEMO_DIR
 
 class TestSomeOf:
     def test_right_number_of_transforms_applied(self):
+        random.seed(23)
         samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
         sample_rate = 44100
-        num_transforms_applied = []
+        num_transforms_applied_list = []
         num_runs = 30
-        num_augmenters = 4
         list_transforms = [
             Gain(min_gain_in_db=-12, max_gain_in_db=-6, p=1.0),
             PolarityInversion(p=1.0),
         ]
+        augmenter = SomeOf(1, list_transforms)
 
-        for i in range(0, num_augmenters):
-            num_transforms_applied_one_augmenter = 0
-            for _ in range(num_runs):
-                augmenter1 = SomeOf(1, list_transforms)
-                augmenter2 = SomeOf((1, 2), list_transforms)
-                augmenter3 = SomeOf((2, None), list_transforms)
-                augmenter4 = SomeOf((0, None), list_transforms)
-                augmenters = [augmenter1, augmenter2, augmenter3, augmenter4]
-                augmenter = augmenters[i]
-                perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+        for _ in range(num_runs):
+            perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+            was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
+            was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+            num_transforms_applied = sum(
+                [
+                    1 if was_gain_applied else 0,
+                    1 if was_polarity_inversion_applied else 0,
+                ]
+            )
+            num_transforms_applied_list.append(num_transforms_applied)
+        assert np.mean(num_transforms_applied_list) == 1
 
-                was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
-                was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+    def test_right_number_of_transforms_applied2(self):
+        random.seed(23)
+        samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
+        sample_rate = 44100
+        num_transforms_applied_list = []
+        num_runs = 30
+        list_transforms = [
+            Gain(min_gain_in_db=-12, max_gain_in_db=-6, p=1.0),
+            PolarityInversion(p=1.0),
+        ]
+        augmenter = SomeOf((1, 2), list_transforms)
 
-                num_transforms_applied_one_iteration = sum(
-                    [
-                        1 if was_gain_applied else 0,
-                        1 if was_polarity_inversion_applied else 0,
-                    ]
-                )
-                num_transforms_applied_one_augmenter += (
-                    num_transforms_applied_one_iteration
-                )
-            num_transforms_applied.append(num_transforms_applied_one_augmenter)
-        assert num_transforms_applied[0] / num_runs == 1
-        assert 1 < num_transforms_applied[1] / num_runs < 2
-        assert num_transforms_applied[2] / num_runs == 2
-        assert 1 < num_transforms_applied[3] / num_runs < 2
+        for _ in range(num_runs):
+            perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+            was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
+            was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+            num_transforms_applied = sum(
+                [
+                    1 if was_gain_applied else 0,
+                    1 if was_polarity_inversion_applied else 0,
+                ]
+            )
+            num_transforms_applied_list.append(num_transforms_applied)
+        assert np.mean(num_transforms_applied_list) == pytest.approx(1.5, abs=0.1)
+
+    def test_right_number_of_transforms_applied3(self):
+        random.seed(23)
+        samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
+        sample_rate = 44100
+        num_transforms_applied_list = []
+        num_runs = 30
+        list_transforms = [
+            Gain(min_gain_in_db=-12, max_gain_in_db=-6, p=1.0),
+            PolarityInversion(p=1.0),
+        ]
+        augmenter = SomeOf((2, None), list_transforms)
+
+        for _ in range(num_runs):
+            perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+            was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
+            was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+            num_transforms_applied = sum(
+                [
+                    1 if was_gain_applied else 0,
+                    1 if was_polarity_inversion_applied else 0,
+                ]
+            )
+            num_transforms_applied_list.append(num_transforms_applied)
+        assert np.mean(num_transforms_applied_list) == 2
+
+    def test_right_number_of_transforms_applied4(self):
+        random.seed(345)
+        samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)
+        sample_rate = 44100
+        num_transforms_applied_list = []
+        num_runs = 30
+        list_transforms = [
+            Gain(min_gain_in_db=-12, max_gain_in_db=-6, p=1.0),
+            PolarityInversion(p=1.0),
+        ]
+        augmenter = SomeOf((0, None), list_transforms)
+
+        for _ in range(num_runs):
+            perturbed_samples = augmenter(samples=samples, sample_rate=sample_rate)
+            was_gain_applied = 0.0 < abs(perturbed_samples[0]) < 0.25
+            was_polarity_inversion_applied = perturbed_samples[0] < 0.0
+            num_transforms_applied = sum(
+                [
+                    1 if was_gain_applied else 0,
+                    1 if was_polarity_inversion_applied else 0,
+                ]
+            )
+            num_transforms_applied_list.append(num_transforms_applied)
+        assert np.mean(num_transforms_applied_list) == pytest.approx(1.0, abs=0.3)
 
     def test_freeze_and_unfreeze_all_parameters(self):
         samples = np.array([0.25, 0.0, 0.1, -0.4], dtype=np.float32)


### PR DESCRIPTION
* Rewrite test code for pytest, so I can use `pytest.mark.parametrize`
* Fix support for mono 2D array
* Fix support for multichannel 2D array that was not stereo
* Move pad width variable to randomize_parameters
* Add pad_section parameter
* Replace with padding instead of inserting padding
* Remove edge option, because it would be result in silence with an "arbitrary" DC offset, which I guess is not a useful way to pad audio
* Rename "constant" to "silence" to be more specific
* Add various cases to the demo script
* Add support for min_fraction=0.0, min_fraction==max_fraction and max_fraction=1.0
* Fix whitespace in padding.py in accordance with the code format of the rest of the repo
* Tweak default value of min_fraction and max_fraction

Close #123