### PR TITLE
Add multichannel audio tests

### DIFF
--- a/tests/test_filter_transforms.py
+++ b/tests/test_filter_transforms.py
@@ -252,7 +252,7 @@ class TestLowShelfFilterTransform:
 
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
-    @pytest.mark.parametrize("q_factor", [0.1, 1.0, 10.0])
+    @pytest.mark.parametrize("q_factor", [0.1, 1.0])
     @pytest.mark.parametrize("num_channels", [2, 3, 4])
     def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
@@ -383,7 +383,7 @@ class TestHighShelfFilterTransform:
 
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
-    @pytest.mark.parametrize("q_factor", [0.1, 1.0, 10.0])
+    @pytest.mark.parametrize("q_factor", [0.1, 1.0])
     @pytest.mark.parametrize("num_channels", [2, 3, 4])
     def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 

--- a/tests/test_filter_transforms.py
+++ b/tests/test_filter_transforms.py
@@ -122,7 +122,7 @@ class TestPeakingFilterTransforms:
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
     @pytest.mark.parametrize("q_factor", [0.1, 1.0, 10.0])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_multi_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
         sample_rate = 8000
@@ -253,7 +253,7 @@ class TestLowShelfFilterTransform:
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
     @pytest.mark.parametrize("q_factor", [0.1, 1.0])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
         sample_rate = 8000
@@ -384,7 +384,7 @@ class TestHighShelfFilterTransform:
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
     @pytest.mark.parametrize("q_factor", [0.1, 1.0])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
         sample_rate = 8000
@@ -539,7 +539,7 @@ class TestLowPassFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_n_channel_input(self, samples, rolloff, zero_phase, num_channels):
 
         sample_rate = 8000
@@ -691,7 +691,7 @@ class TestHighPassFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_n_channel_input(self, samples, rolloff, zero_phase, num_channels):
 
         sample_rate = 8000
@@ -887,7 +887,7 @@ class TestBandPassFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_two_channel_input(
         self,
         center_frequency,
@@ -1110,7 +1110,7 @@ class TestBandStopFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    @pytest.mark.parametrize("num_channels", [1, 2, 3])
     def test_two_channel_input(
         self,
         center_frequency,

--- a/tests/test_filter_transforms.py
+++ b/tests/test_filter_transforms.py
@@ -262,7 +262,7 @@ class TestLowShelfFilterTransform:
         # Convert to 2D N channels
         n_channels = np.tile(samples, (num_channels, 1))
 
-        augment = PeakingFilter(
+        augment = LowShelfFilter(
             min_center_freq=center_freq,
             max_center_freq=center_freq,
             min_gain_db=gain_db,
@@ -393,7 +393,7 @@ class TestHighShelfFilterTransform:
         # Convert to 2D N channels
         n_channels = np.tile(samples, (num_channels, 1))
 
-        augment = PeakingFilter(
+        augment = HighShelfFilter(
             min_center_freq=center_freq,
             max_center_freq=center_freq,
             min_gain_db=gain_db,

--- a/tests/test_filter_transforms.py
+++ b/tests/test_filter_transforms.py
@@ -254,7 +254,7 @@ class TestLowShelfFilterTransform:
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
     @pytest.mark.parametrize("q_factor", [0.1, 1.0, 10.0])
     @pytest.mark.parametrize("num_channels", [2, 3, 4])
-    def test_two_channel_input(self, center_freq, gain_db, q_factor, num_channels):
+    def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
         sample_rate = 8000
         samples = get_randn_test(sample_rate, 10)
@@ -384,13 +384,14 @@ class TestHighShelfFilterTransform:
     @pytest.mark.parametrize("center_freq", [10.0, 2000.0, 3900.0])
     @pytest.mark.parametrize("gain_db", [0.0, -6.0, +6.0])
     @pytest.mark.parametrize("q_factor", [0.1, 1.0, 10.0])
-    def test_two_channel_input(self, center_freq, gain_db, q_factor):
+    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    def test_n_channel_input(self, center_freq, gain_db, q_factor, num_channels):
 
         sample_rate = 8000
         samples = get_randn_test(sample_rate, 10)
 
-        # Convert to 2D two channels
-        two_channels = np.vstack([samples, samples])
+        # Convert to 2D N channels
+        n_channels = np.tile(samples, (num_channels, 1))
 
         augment = PeakingFilter(
             min_center_freq=center_freq,
@@ -404,15 +405,15 @@ class TestHighShelfFilterTransform:
 
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        processed_two_channels = augment(samples=two_channels, sample_rate=sample_rate)
+        processed_n_channels = augment(samples=n_channels, sample_rate=sample_rate)
 
-        assert processed_two_channels.shape[0] == 2
-        assert processed_two_channels.shape == two_channels.shape
-        assert processed_two_channels.dtype == np.float32
+        assert processed_n_channels.shape[0] == num_channels
+        assert processed_n_channels.shape == n_channels.shape
+        assert processed_n_channels.dtype == np.float32
 
         # Check that the processed 2D channel version applies the same effect
         # as the passband version.
-        for _, channel in enumerate(processed_two_channels):
+        for _, channel in enumerate(processed_n_channels):
             if DEBUG:
                 import matplotlib.pyplot as plt
 
@@ -430,7 +431,12 @@ class TestLowPassFilterTransform:
     @pytest.mark.parametrize("cutoff_frequency", [1000])
     @pytest.mark.parametrize("rolloff", [6, 24])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    def test_one_single_input(self, cutoff_frequency, rolloff, zero_phase):
+    def test_one_single_input(
+        self,
+        cutoff_frequency,
+        rolloff,
+        zero_phase,
+    ):
 
         sample_rate = 8000
 
@@ -529,6 +535,51 @@ class TestLowPassFilterTransform:
                 expected_differences[n],
                 atol=tolerances[n],
             )
+
+    @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
+    @pytest.mark.parametrize("rolloff", [12, 120])
+    @pytest.mark.parametrize("zero_phase", [False, True])
+    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    def test_n_channel_input(self, samples, rolloff, zero_phase, num_channels):
+
+        sample_rate = 8000
+        samples = get_randn_test(sample_rate, 10)
+
+        # Convert to 2D N channels
+        n_channels = np.tile(samples, (num_channels, 1))
+
+        augment = LowPassFilter(
+            min_cutoff_freq=1000,
+            max_cutoff_freq=1000,
+            min_rolloff=rolloff,
+            max_rolloff=rolloff,
+            zero_phase=zero_phase,
+            p=1.0,
+        )
+
+        processed_samples = augment(samples=samples, sample_rate=sample_rate)
+
+        processed_n_channels = augment(samples=n_channels, sample_rate=sample_rate)
+
+        assert processed_n_channels.shape[0] == num_channels
+        assert processed_n_channels.shape == n_channels.shape
+        assert processed_n_channels.dtype == np.float32
+
+        # Check that the processed 2D channel version applies the same effect
+        # as the passband version.
+        for _, channel in enumerate(processed_n_channels):
+            if DEBUG:
+                import matplotlib.pyplot as plt
+
+                plt.title(
+                    f"Filter type: Low-pass Roll-off:{rolloff}db/octave Zero-phase:{zero_phase}"
+                )
+                plt.plot(processed_samples)
+                plt.plot(channel, "r--")
+
+                plt.legend(["1D", "2D"])
+                plt.show()
+            assert np.allclose(channel, processed_samples)
 
 
 class TestHighPassFilterTransform:
@@ -640,13 +691,14 @@ class TestHighPassFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
-    def test_two_channel_input(self, samples, rolloff, zero_phase):
+    @pytest.mark.parametrize("num_channels", [2, 3, 4])
+    def test_n_channel_input(self, samples, rolloff, zero_phase, num_channels):
 
         sample_rate = 8000
         samples = get_randn_test(sample_rate, 10)
 
-        # Convert to 2D two channels
-        two_channels = np.vstack([samples, samples])
+        # Convert to 2D N channels
+        n_channels = np.tile(samples, (num_channels, 1))
 
         augment = HighPassFilter(
             min_cutoff_freq=1000,
@@ -659,15 +711,15 @@ class TestHighPassFilterTransform:
 
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        processed_two_channels = augment(samples=two_channels, sample_rate=sample_rate)
+        processed_n_channels = augment(samples=n_channels, sample_rate=sample_rate)
 
-        assert processed_two_channels.shape[0] == 2
-        assert processed_two_channels.shape == two_channels.shape
-        assert processed_two_channels.dtype == np.float32
+        assert processed_n_channels.shape[0] == num_channels
+        assert processed_n_channels.shape == n_channels.shape
+        assert processed_n_channels.dtype == np.float32
 
         # Check that the processed 2D channel version applies the same effect
         # as the passband version.
-        for _, channel in enumerate(processed_two_channels):
+        for _, channel in enumerate(processed_n_channels):
             if DEBUG:
                 import matplotlib.pyplot as plt
 
@@ -835,15 +887,22 @@ class TestBandPassFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
+    @pytest.mark.parametrize("num_channels", [2, 3, 4])
     def test_two_channel_input(
-        self, center_frequency, bandwidth_fraction, samples, rolloff, zero_phase
+        self,
+        center_frequency,
+        bandwidth_fraction,
+        samples,
+        rolloff,
+        zero_phase,
+        num_channels,
     ):
 
         sample_rate = 16000
         samples = get_randn_test(sample_rate, 10)
 
-        # Convert to 2D two channels
-        two_channels = np.vstack([samples, samples])
+        # Convert to 2D N channels
+        n_channels = np.tile(samples, (num_channels, 1))
 
         augment = BandPassFilter(
             min_center_freq=center_frequency,
@@ -858,15 +917,15 @@ class TestBandPassFilterTransform:
 
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        processed_two_channels = augment(samples=two_channels, sample_rate=sample_rate)
+        processed_n_channels = augment(samples=n_channels, sample_rate=sample_rate)
 
-        assert processed_two_channels.shape[0] == 2
-        assert processed_two_channels.shape == two_channels.shape
-        assert processed_two_channels.dtype == np.float32
+        assert processed_n_channels.shape[0] == num_channels
+        assert processed_n_channels.shape == n_channels.shape
+        assert processed_n_channels.dtype == np.float32
 
         # Check that the processed 2D channel version applies the same effect
         # as the passband version.
-        for _, channel in enumerate(processed_two_channels):
+        for _, channel in enumerate(processed_n_channels):
             if DEBUG:
                 import matplotlib.pyplot as plt
 
@@ -1051,15 +1110,22 @@ class TestBandStopFilterTransform:
     @pytest.mark.parametrize("samples", [get_chirp_test(8000, 40)])
     @pytest.mark.parametrize("rolloff", [12, 120])
     @pytest.mark.parametrize("zero_phase", [False, True])
+    @pytest.mark.parametrize("num_channels", [2, 3, 4])
     def test_two_channel_input(
-        self, center_frequency, bandwidth_fraction, samples, rolloff, zero_phase
+        self,
+        center_frequency,
+        bandwidth_fraction,
+        samples,
+        rolloff,
+        zero_phase,
+        num_channels,
     ):
 
         sample_rate = 16000
         samples = get_randn_test(sample_rate, 10)
 
-        # Convert to 2D two channels
-        two_channels = np.vstack([samples, samples])
+        # Convert to 2D N channels
+        n_channels = np.tile(samples, (num_channels, 1))
 
         augment = BandStopFilter(
             min_center_freq=center_frequency,
@@ -1074,15 +1140,15 @@ class TestBandStopFilterTransform:
 
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        processed_two_channels = augment(samples=two_channels, sample_rate=sample_rate)
+        processed_n_channels = augment(samples=n_channels, sample_rate=sample_rate)
 
-        assert processed_two_channels.shape[0] == 2
-        assert processed_two_channels.shape == two_channels.shape
-        assert processed_two_channels.dtype == np.float32
+        assert processed_n_channels.shape[0] == num_channels
+        assert processed_n_channels.shape == n_channels.shape
+        assert processed_n_channels.dtype == np.float32
 
         # Check that the processed 2D channel version applies the same effect
         # as the passband version.
-        for _, channel in enumerate(processed_two_channels):
+        for _, channel in enumerate(processed_n_channels):
             if DEBUG:
                 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
- Extend the tests to cover n channel cases instead of just two.
- Add missing multichannel test for the Lowpass filter