### PR TITLE
Unittest to pytest

### DIFF
--- a/tests/test_gaussian_snr.py
+++ b/tests/test_gaussian_snr.py
@@ -43,5 +43,5 @@ class TestGaussianSNR:
         samples_out = augmenter(samples=samples, sample_rate=16000)
 
         assert samples_out.dtype == np.float32
-        assert float(np.sum(np.abs(samples_out))) > float(np.sum(np.abs(samples_out)))
+        assert float(np.sum(np.abs(samples_out))) > float(np.sum(np.abs(samples)))
 

--- a/tests/test_gaussian_snr.py
+++ b/tests/test_gaussian_snr.py
@@ -1,12 +1,12 @@
 import json
-import unittest
+import pytest
 
 import numpy as np
 
 from audiomentations import AddGaussianSNR
 
 
-class TestGaussianSNR(unittest.TestCase):
+class TestGaussianSNR:
     def test_gaussian_noise_snr_defaults(self):
         np.random.seed(42)
         samples_in = np.random.normal(0, 1, size=1024).astype(np.float32)
@@ -15,8 +15,8 @@ class TestGaussianSNR(unittest.TestCase):
         samples_out = augmenter(samples=samples_in, sample_rate=16000)
         std_out = np.mean(np.abs(samples_out))
         assert samples_out.dtype == np.float32
-        self.assertNotAlmostEqual(float(std_out), 0.0)
-        self.assertGreater(std_out, std_in)
+        assert not (float(std_out) == pytest.approx(0.0))
+        assert std_out > std_in
 
     def test_gaussian_noise_snr(self):
         np.random.seed(42)
@@ -26,8 +26,8 @@ class TestGaussianSNR(unittest.TestCase):
         samples_out = augmenter(samples=samples_in, sample_rate=16000)
         std_out = np.mean(np.abs(samples_out))
         assert samples_out.dtype == np.float32
-        self.assertNotAlmostEqual(float(std_out), 0.0)
-        self.assertGreater(std_out, std_in)
+        assert not (float(std_out) == pytest.approx(0.0))
+        assert std_out > std_in
 
     def test_serialize_parameters(self):
         np.random.seed(42)
@@ -43,6 +43,5 @@ class TestGaussianSNR(unittest.TestCase):
         samples_out = augmenter(samples=samples, sample_rate=16000)
 
         assert samples_out.dtype == np.float32
-        self.assertGreater(
-            float(np.sum(np.abs(samples_out))), float(np.sum(np.abs(samples)))
-        )
+        assert float(np.sum(np.abs(samples_out))) > float(np.sum(np.abs(samples_out)))
+

--- a/tests/test_load_sound_files.py
+++ b/tests/test_load_sound_files.py
@@ -1,6 +1,6 @@
 import math
 import os
-import unittest
+import pytest
 import warnings
 
 import numpy as np
@@ -11,166 +11,163 @@ from audiomentations.core.audio_loading_utils import (
 from demo.demo import DEMO_DIR
 
 
-class TestLoadSoundFiles(unittest.TestCase):
+class TestLoadSoundFiles:
     def test_load_stereo_ogg_vorbis(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "background_noises", "hens.ogg"), sample_rate=None
         )
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
         # Apparently, the exact duration may vary slightly based on which decoder is used
-        self.assertGreaterEqual(samples.shape[0], 442575)
-        self.assertLessEqual(samples.shape[0], 443328)
+        assert samples.shape[0] >= 442575
+        assert samples.shape[0] <= 443328
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.02)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.02
+        assert max_value < 1.0
 
     def test_load_mono_opus(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "bus.opus"), sample_rate=None
         )
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
         # Apparently, the exact duration may vary slightly based on which decoder is used
-        self.assertGreaterEqual(samples.shape[0], 36682)
-        self.assertLessEqual(samples.shape[0], 36994)
+        assert samples.shape[0] >= 36682
+        assert samples.shape[0] <= 36994
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.3)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.3
+        assert max_value < 1.0
 
     def test_load_mono_m4a(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "testing.m4a"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 44100)
+        assert sample_rate == 44100
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
-
-        self.assertGreaterEqual(samples.shape[0], 141312)
-        self.assertLessEqual(samples.shape[0], 141312)
+        assert samples.ndim == 1
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.1)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.1
+        assert max_value < 1.0
 
     def test_load_mono_signed_16_bit_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "acoustic_guitar_0.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 16000)
+        assert sample_rate == 16000
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
-
-        self.assertEqual(samples.shape[0], 140544)
+        assert samples.ndim == 1
+        
+        assert samples.shape[0] == 140544
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.5)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.5
+        assert max_value < 1.0
 
     def test_load_stereo_signed_16_bit_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "stereo_16bit.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 16000)
+        assert sample_rate == 16000
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[0], 17833)
+        assert samples.shape[0] == 17833
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.5)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.5
+        assert max_value < 1.0
 
     def test_load_mono_signed_24_bit_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "signed_24bit.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 48000)
+        assert sample_rate == 48000
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[0], 54514)
+        assert samples.shape[0] == 54514
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.09)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.09
+        assert max_value < 1.0
 
     def test_load_mono_signed_24_bit_wav2(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "mono_int24.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 44100)
+        assert sample_rate == 44100
         assert samples.dtype == np.float32
-        self.assertEqual(samples.ndim, 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[-1], 22)
+        assert samples.shape[-1] == 22
 
         max_value = np.amax(samples)
-        self.assertAlmostEqual(max_value, 0.96750367)
+        assert max_value == pytest.approx(0.96750367)
         min_value = np.amin(samples)
-        self.assertAlmostEqual(min_value, -0.9822748)
+        assert min_value == pytest.approx(-0.9822748)
 
     def test_load_mono_signed_32_bit_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "mono_int32.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 44100)
+        assert sample_rate == 44100
         assert samples.dtype == np.float32
-        self.assertEqual(samples.ndim, 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[-1], 22)
+        assert samples.shape[-1] == 22
 
         max_value = np.amax(samples)
-        self.assertAlmostEqual(max_value, 0.96750367)
+        assert max_value == pytest.approx(0.96750367)
         min_value = np.amin(samples)
-        self.assertAlmostEqual(min_value, -0.9822748)
+        assert min_value == pytest.approx(-0.9822748)
 
     def test_load_mono_float64_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "mono_float64.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 44100)
+        assert sample_rate == 44100
         assert samples.dtype == np.float32
-        self.assertEqual(samples.ndim, 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[-1], 22)
+        assert samples.shape[-1] == 22
 
         max_value = np.amax(samples)
-        self.assertAlmostEqual(max_value, 0.96750367)
+        assert max_value == pytest.approx(0.96750367)
         min_value = np.amin(samples)
-        self.assertAlmostEqual(min_value, -0.9822748)
+        assert min_value == pytest.approx(-0.9822748)
 
     def test_load_stereo_signed_24_bit_wav(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "stereo_24bit.WAV"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 16000)
+        assert sample_rate == 16000
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[0], 17833)
+        assert samples.shape[0] == 17833
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.5)
-        self.assertLess(max_value, 1.0)
-
+        assert max_value > 0.5
+        assert max_value < 1.0
+        
     def test_load_mono_ms_adpcm(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "ms_adpcm.wav"), sample_rate=None
         )
-        self.assertEqual(sample_rate, 11024)
+        assert sample_rate == 11024
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[0], 895500)
+        assert samples.shape[0] == 895500
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.3)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.3
+        assert max_value < 1.0
 
     def test_load_mono_ms_adpcm_and_resample(self):
         with warnings.catch_warnings(record=True) as w:
@@ -187,12 +184,13 @@ class TestLoadSoundFiles(unittest.TestCase):
                 in str(w[-1].message)
             )
 
-        self.assertEqual(sample_rate, 16000)
+        assert sample_rate == 16000
         assert samples.dtype == np.float32
-        self.assertEqual(len(samples.shape), 1)
+        assert samples.ndim == 1
 
-        self.assertEqual(samples.shape[0], math.ceil(895500 * 16000 / 11024))
+        assert samples.shape[0] == math.ceil(895500 * 16000 / 11024)
 
         max_value = np.amax(samples)
-        self.assertGreater(max_value, 0.3)
-        self.assertLess(max_value, 1.0)
+        assert max_value > 0.3
+        assert max_value < 1.0
+        

--- a/tests/test_loudness_normalization.py
+++ b/tests/test_loudness_normalization.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal
 from audiomentations import LoudnessNormalization
 
 
-class TestLoudnessNormalization(unittest.TestCase):
+class TestLoudnessNormalization:
     def test_loudness_normalization(self):
         samples = np.random.uniform(low=-0.2, high=-0.001, size=(8000,)).astype(
             np.float32
@@ -16,8 +16,8 @@ class TestLoudnessNormalization(unittest.TestCase):
         augment = LoudnessNormalization(min_lufs_in_db=-32, max_lufs_in_db=-12, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
         gain_factors = processed_samples / samples
-        self.assertAlmostEqual(np.amin(gain_factors), np.amax(gain_factors), places=6)
-        self.assertEqual(processed_samples.dtype, np.float32)
+        assert np.amin(gain_factors) == pytest.approx(np.amax(gain_factors))
+        assert processed_samples.dtype == np.float32
 
     def test_loudness_normalization_digital_silence(self):
         samples = np.zeros(8000, dtype=np.float32)
@@ -26,7 +26,7 @@ class TestLoudnessNormalization(unittest.TestCase):
         augment = LoudnessNormalization(min_lufs_in_db=-32, max_lufs_in_db=-12, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
         assert_almost_equal(processed_samples, np.zeros(8000, dtype=np.float32))
-        self.assertEqual(processed_samples.dtype, np.float32)
+        assert processed_samples.dtype == np.float32
 
     def test_loudness_normalization_too_short_input(self):
         samples = np.random.uniform(low=-0.2, high=-0.001, size=(800,)).astype(
@@ -35,7 +35,7 @@ class TestLoudnessNormalization(unittest.TestCase):
         sample_rate = 16000
 
         augment = LoudnessNormalization(min_lufs_in_db=-32, max_lufs_in_db=-12, p=1.0)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             _ = augment(samples=samples, sample_rate=sample_rate)
 
     def test_loudness_normalization_multichannel(self):
@@ -47,5 +47,5 @@ class TestLoudnessNormalization(unittest.TestCase):
         augment = LoudnessNormalization(min_lufs_in_db=-32, max_lufs_in_db=-12, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
         gain_factors = processed_samples / samples
-        self.assertAlmostEqual(np.amin(gain_factors), np.amax(gain_factors), places=6)
-        self.assertEqual(processed_samples.dtype, np.float32)
+        assert np.amin(gain_factors) == pytest.approx(np.amax(gain_factors))
+        assert processed_samples.dtype == np.float32

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 from numpy.testing import assert_almost_equal
 
 from audiomentations import Shift, Compose
 
 
-class TestShift(unittest.TestCase):
+class TestShift:
     def test_shift(self):
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
         sample_rate = 16000
@@ -18,8 +16,8 @@ class TestShift(unittest.TestCase):
         assert_almost_equal(
             forward_shifted_samples, np.array([0.25, 0.125, 1.0, 0.5], dtype=np.float32)
         )
-        self.assertEqual(forward_shifted_samples.dtype, np.float32)
-        self.assertEqual(len(forward_shifted_samples), 4)
+        assert forward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
 
         backward_augmenter = Compose(
             [Shift(min_fraction=-0.25, max_fraction=-0.25, p=1.0)]
@@ -31,8 +29,8 @@ class TestShift(unittest.TestCase):
             backward_shifted_samples,
             np.array([0.5, 0.25, 0.125, 1.0], dtype=np.float32),
         )
-        self.assertEqual(backward_shifted_samples.dtype, np.float32)
-        self.assertEqual(len(backward_shifted_samples), 4)
+        assert backward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
 
     def test_shift_without_rollover(self):
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
@@ -47,8 +45,8 @@ class TestShift(unittest.TestCase):
         assert_almost_equal(
             forward_shifted_samples, np.array([0.0, 0.0, 1.0, 0.5], dtype=np.float32)
         )
-        self.assertEqual(forward_shifted_samples.dtype, np.float32)
-        self.assertEqual(len(forward_shifted_samples), 4)
+        assert forward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
 
         backward_augmenter = Compose(
             [Shift(min_fraction=-0.25, max_fraction=-0.25, rollover=False, p=1.0)]
@@ -60,8 +58,8 @@ class TestShift(unittest.TestCase):
             backward_shifted_samples,
             np.array([0.5, 0.25, 0.125, 0.0], dtype=np.float32),
         )
-        self.assertEqual(backward_shifted_samples.dtype, np.float32)
-        self.assertEqual(len(backward_shifted_samples), 4)
+        assert backward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
 
     def test_shift_multichannel(self):
         samples = np.array(
@@ -79,7 +77,7 @@ class TestShift(unittest.TestCase):
                 dtype=np.float32,
             ),
         )
-        self.assertEqual(processed_samples.dtype, np.float32)
+        assert processed_samples.dtype == np.float32
 
     def test_shift_without_rollover_multichannel(self):
         samples = np.array(
@@ -94,7 +92,7 @@ class TestShift(unittest.TestCase):
             processed_samples,
             np.array([[0.0, 0.0, 0.75, 0.5], [0.0, 0.0, 0.9, 0.5]], dtype=np.float32),
         )
-        self.assertEqual(processed_samples.dtype, np.float32)
+        assert processed_samples.dtype == np.float32
 
     def test_shift_fade(self):
         samples = np.array(

--- a/tests/test_spec_channel_shuffle.py
+++ b/tests/test_spec_channel_shuffle.py
@@ -1,5 +1,5 @@
 import os
-import unittest
+import pytest
 
 import librosa
 import numpy as np
@@ -13,7 +13,7 @@ from .utils import plot_matrix
 DEBUG = False
 
 
-class TestSpecChannelShuffle(unittest.TestCase):
+class TestSpecChannelShuffle:
     def test_shuffle_channels(self):
         samples, sample_rate = load_sound_file(
             os.path.join(DEMO_DIR, "background_noises", "hens.ogg"),
@@ -79,7 +79,7 @@ class TestSpecChannelShuffle(unittest.TestCase):
         )
 
         transform = SpecChannelShuffle(p=1.0)
-        with self.assertRaises(MonoAudioNotSupportedException):
+        with pytest.raises(MonoAudioNotSupportedException):
             augmented_spectrogram = transform(magnitude_spectrogram)
 
     def test_empty_spectrogram(self):

--- a/tests/test_time_mask.py
+++ b/tests/test_time_mask.py
@@ -1,12 +1,10 @@
-import unittest
-
 import numpy as np
 import pytest
 
 from audiomentations import TimeMask, Compose
 
 
-class TestTimeMask(unittest.TestCase):
+class TestTimeMask:
     def test_apply_time_mask(self):
         sample_len = 1024
         samples_in = np.random.normal(0, 1, size=sample_len).astype(np.float32)
@@ -15,11 +13,11 @@ class TestTimeMask(unittest.TestCase):
 
         samples_out = augmenter(samples=samples_in, sample_rate=sample_rate)
         assert samples_out.dtype == np.float32
-        self.assertEqual(len(samples_out), sample_len)
+        assert len(samples_out) == sample_len
 
         std_in = np.mean(np.abs(samples_in))
         std_out = np.mean(np.abs(samples_out))
-        self.assertLess(std_out, std_in)
+        assert std_out < std_in
 
     def test_invalid_params(self):
         with pytest.raises(ValueError):
@@ -39,11 +37,11 @@ class TestTimeMask(unittest.TestCase):
 
         samples_out = augmenter(samples=samples_in, sample_rate=sample_rate)
         assert samples_out.dtype == np.float32
-        self.assertEqual(samples_out.shape, samples_in.shape)
+        assert samples_out.shape == samples_in.shape
 
         std_in = np.mean(np.abs(samples_in))
         std_out = np.mean(np.abs(samples_out))
-        self.assertLess(std_out, std_in)
+        assert std_out < std_in
 
     def test_apply_time_mask_with_fade(self):
         sample_len = 1024
@@ -55,11 +53,11 @@ class TestTimeMask(unittest.TestCase):
 
         samples_out = augmenter(samples=samples_in, sample_rate=sample_rate)
         assert samples_out.dtype == np.float32
-        self.assertEqual(len(samples_out), sample_len)
+        assert len(samples_out) == sample_len
 
         std_in = np.mean(np.abs(samples_in))
         std_out = np.mean(np.abs(samples_out))
-        self.assertLess(std_out, std_in)
+        assert std_out < std_in
 
     def test_apply_time_mask_with_fade_short_signal(self):
         sample_len = 100
@@ -71,8 +69,8 @@ class TestTimeMask(unittest.TestCase):
 
         samples_out = augmenter(samples=samples_in, sample_rate=sample_rate)
         assert samples_out.dtype == np.float32
-        self.assertEqual(len(samples_out), sample_len)
+        assert len(samples_out) == sample_len
 
         std_in = np.mean(np.abs(samples_in))
         std_out = np.mean(np.abs(samples_out))
-        self.assertLess(std_out, std_in)
+        assert std_out < std_in

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 from audiomentations.core.utils import (
     calculate_desired_noise_rms,
     convert_decibels_to_amplitude_ratio,
-    find_audio_files_in_paths,
+    get_file_paths,
     calculate_rms,
     calculate_rms_without_silence,
 )
@@ -24,7 +24,7 @@ class TestUtils:
         assert amplitude_ratio == pytest.approx(1.9952623149688795)
 
     def test_find_audio_files_in_paths_uppercase_extension(self):
-        file_paths = find_audio_files_in_paths(DEMO_DIR, traverse_subdirectories=False)
+        file_paths = get_file_paths(DEMO_DIR, traverse_subdirectories=False)
         found_it = False
         for file_path in file_paths:
             if file_path.name == "stereo_24bit.WAV":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ class TestUtils:
         amplitude_ratio = convert_decibels_to_amplitude_ratio(decibels=6)
         assert amplitude_ratio == pytest.approx(1.9952623149688795)
 
-    def test_find_audio_files_in_paths_uppercase_extension(self):
+    def test_get_file_paths_uppercase_extension(self):
         file_paths = get_file_paths(DEMO_DIR, traverse_subdirectories=False)
         found_it = False
         for file_path in file_paths:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 from audiomentations.core.utils import (
     calculate_desired_noise_rms,
     convert_decibels_to_amplitude_ratio,
-    get_file_paths,
+    find_audio_files_in_paths,
     calculate_rms,
     calculate_rms_without_silence,
 )
@@ -23,8 +23,8 @@ class TestUtils:
         amplitude_ratio = convert_decibels_to_amplitude_ratio(decibels=6)
         assert amplitude_ratio == pytest.approx(1.9952623149688795)
 
-    def test_get_file_paths_uppercase_extension(self):
-        file_paths = get_file_paths(DEMO_DIR, traverse_subdirectories=False)
+    def test_find_audio_files_in_paths_uppercase_extension(self):
+        file_paths = find_audio_files_in_paths(DEMO_DIR, traverse_subdirectories=False)
         found_it = False
         for file_path in file_paths:
             if file_path.name == "stereo_24bit.WAV":


### PR DESCRIPTION
Implements https://github.com/iver56/audiomentations/issues/176, except from `unittest.mock` in `test_room_simulator.py`. I can replace it with `pytest-mock` if necessary.