### PR TITLE
Moved the calculation of noise_rms in the background noise transform

### DIFF
--- a/audiomentations/augmentations/add_background_noise.py
+++ b/audiomentations/augmentations/add_background_noise.py
@@ -123,6 +123,9 @@ class AddBackgroundNoise(BaseWaveformTransform):
             self.parameters["noise_start_index"] : self.parameters["noise_end_index"]
         ]
 
+        if self.noise_transform:
+            noise_sound = self.noise_transform(noise_sound, sample_rate)
+
         noise_rms = calculate_rms(noise_sound)
         if noise_rms < 1e-9:
             warnings.warn(
@@ -130,9 +133,6 @@ class AddBackgroundNoise(BaseWaveformTransform):
                 " unchanged.".format(self.parameters["noise_file_path"])
             )
             return samples
-
-        if self.noise_transform:
-            noise_sound = self.noise_transform(noise_sound, sample_rate)
 
         clean_rms = calculate_rms(samples)
 


### PR DESCRIPTION
Fixed a bug where the rms of the background nosie would be calculated before applying oprtional transforms to the background noise.

Should I add a test for that ?