### PR TITLE
Add sample rate augmentation

### DIFF
--- a/audiomentations/__init__.py
+++ b/audiomentations/__init__.py
@@ -27,6 +27,7 @@ from .augmentations.shift import Shift
 from .augmentations.tanh_distortion import TanhDistortion
 from .augmentations.time_mask import TimeMask
 from .augmentations.time_stretch import TimeStretch
+from .augmentations.sample_rate_change import SampleRateChange
 from .augmentations.trim import Trim
 from .core.composition import Compose, SpecCompose, OneOf, SomeOf
 from .spec_augmentations.spec_channel_shuffle import SpecChannelShuffle

--- a/audiomentations/augmentations/sample_rate_change.py
+++ b/audiomentations/augmentations/sample_rate_change.py
@@ -1,0 +1,48 @@
+import random
+
+import librosa
+import numpy as np
+
+from audiomentations.core.transforms_interface import BaseWaveformTransform
+
+
+class SampleRateChange(BaseWaveformTransform):
+    """Time stretch the signal with matching change of the pitch"""
+
+    supports_multichannel = True
+
+    def __init__(self, min_rate=0.8, max_rate=1.25, leave_length_unchanged=True, p=0.5):
+        super().__init__(p)
+        assert min_rate > 0.1
+        assert max_rate < 10
+        assert min_rate <= max_rate
+        self.min_rate = min_rate
+        self.max_rate = max_rate
+        self.leave_length_unchanged = leave_length_unchanged
+
+    def randomize_parameters(self, samples, sample_rate):
+        super().randomize_parameters(samples, sample_rate)
+        if self.parameters["should_apply"]:
+            """
+            If rate > 1, then the signal is sped up.
+            If rate < 1, then the signal is slowed down.
+            """
+            self.parameters["rate"] = random.uniform(self.min_rate, self.max_rate)
+
+    def apply(self, samples, sample_rate):
+        augmented_samples = librosa.core.resample(
+            samples,
+            orig_sr=sample_rate,
+            target_sr=self.parameters["rate"]*sample_rate,
+        )
+        if self.leave_length_unchanged:
+            # Apply zero padding if the time stretched audio is not long enough to fill the
+            # whole space, or crop the time stretched audio if it ended up too long.
+            padded_samples = np.zeros(shape=samples.shape, dtype=samples.dtype)
+            window = augmented_samples[..., : samples.shape[-1]]
+            actual_window_length = window.shape[
+                -1
+            ]  # may be smaller than samples.shape[-1]
+            padded_samples[..., :actual_window_length] = window
+            augmented_samples = padded_samples
+        return augmented_samples

--- a/audiomentations/augmentations/sample_rate_change.py
+++ b/audiomentations/augmentations/sample_rate_change.py
@@ -24,8 +24,8 @@ class SampleRateChange(BaseWaveformTransform):
         super().randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"]:
             """
-            If rate > 1, then the signal is sped up.
-            If rate < 1, then the signal is slowed down.
+            If rate < 1, then the signal is sped up.
+            If rate > 1, then the signal is slowed down.
             """
             self.parameters["rate"] = random.uniform(self.min_rate, self.max_rate)
 


### PR DESCRIPTION
TimeStretch and Pitch augment can create heavy artifacts.
For some use cases it might be better to change the speed by changing the sample-rate even if that entails creating wrong correlation between pitch and speed.

If you agree with the usefulness, I'll add tests and I'm also opened to name change as I was not very inspired haha