### PR TITLE
Use the correct  corner coordinates when constructing the shoebox room

### DIFF
--- a/audiomentations/augmentations/room_simulator.py
+++ b/audiomentations/augmentations/room_simulator.py
@@ -287,9 +287,9 @@ class RoomSimulator(BaseWaveformTransform):
             np.array(
                 [
                     [0, 0],
-                    [0, self.parameters["size_x"]],
+                    [0, self.parameters["size_y"]],
                     [self.parameters["size_x"], self.parameters["size_y"]],
-                    [self.parameters["size_y"], 0],
+                    [self.parameters["size_x"], 0],
                 ]
             ).T,
             fs=sample_rate,
@@ -334,7 +334,6 @@ class RoomSimulator(BaseWaveformTransform):
                 self.room.fs,
             )
         )
-
         # Do the simulation
         self.room.compute_rir()
 


### PR DESCRIPTION
This PR specifies correctly the room corner coordinates when building the shoebox room. Before I accidentally had the `x` and `y` coordinates swapped in one case which lead to a microphone leaving the room borders in some cases and causing the behaviour in #201.

Fixes #201