### PR TITLE
modify shift and add test

### DIFF
--- a/audiomentations/augmentations/shift.py
+++ b/audiomentations/augmentations/shift.py
@@ -49,15 +49,14 @@ class Shift(BaseWaveformTransform):
     def randomize_parameters(self, samples, sample_rate):
         super().randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"]:
-            self.parameters["num_places_to_shift"] = int(
-                round(
-                    random.uniform(self.min_fraction, self.max_fraction)
-                    * samples.shape[-1]
-                )
+            self.parameters["fraction_to_shift"] = random.uniform(
+                self.min_fraction, self.max_fraction
             )
 
     def apply(self, samples, sample_rate):
-        num_places_to_shift = self.parameters["num_places_to_shift"]
+        num_places_to_shift = round(
+            self.parameters["fraction_to_shift"] * samples.shape[-1]
+        )
         shifted_samples = np.roll(samples, num_places_to_shift, axis=-1)
 
         if not self.rollover:
@@ -80,10 +79,9 @@ class Shift(BaseWaveformTransform):
                 )
                 fade_in_length = fade_in_end - fade_in_start
 
-                shifted_samples[
-                ...,
-                fade_in_start:fade_in_end,
-                ] *= fade_in[:fade_in_length]
+                shifted_samples[..., fade_in_start:fade_in_end,] *= fade_in[
+                    :fade_in_length
+                ]
 
                 if self.rollover:
 
@@ -92,8 +90,8 @@ class Shift(BaseWaveformTransform):
                     fade_out_length = fade_out_end - fade_out_start
 
                     shifted_samples[..., fade_out_start:fade_out_end] *= fade_out[
-                                                                         -fade_out_length:
-                                                                         ]
+                        -fade_out_length:
+                    ]
 
             elif num_places_to_shift < 0:
 
@@ -106,19 +104,18 @@ class Shift(BaseWaveformTransform):
                 fade_out_length = fade_out_end - fade_out_start
 
                 shifted_samples[..., fade_out_start:fade_out_end] *= fade_out[
-                                                                     -fade_out_length:
-                                                                     ]
+                    -fade_out_length:
+                ]
 
                 if self.rollover:
                     fade_in_start = positive_num_places_to_shift
                     fade_in_end = min(
                         positive_num_places_to_shift + fade_length,
                         shifted_samples.shape[-1],
-                        )
+                    )
                     fade_in_length = fade_in_end - fade_in_start
-                    shifted_samples[
-                    ...,
-                    fade_in_start:fade_in_end,
-                    ] *= fade_in[:fade_in_length]
+                    shifted_samples[..., fade_in_start:fade_in_end,] *= fade_in[
+                        :fade_in_length
+                    ]
 
         return shifted_samples

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -138,8 +138,7 @@ class TestShift:
         assert_almost_equal(
             processed_samples,
             np.array(
-                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]],
-                dtype=np.float32,
+                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]], dtype=np.float32,
             ),
         )
 
@@ -193,3 +192,26 @@ class TestShift:
                 dtype=np.float32,
             ),
         )
+
+    def test_freeze_shift_with_different_sample_rates(self):
+        samples1 = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
+        samples2 = np.array(
+            [1.0, 0.5, 0.25, 0.125, 0.3, 0.4, 0.5, 0.2], dtype=np.float32
+        )
+        sample_rate_1 = 1
+        sample_rate_2 = 2
+
+        augment = Shift(
+            min_fraction=0.5, max_fraction=0.5, rollover=False, fade=False, p=1.0
+        )
+        augment.randomize_parameters(samples1, sample_rate_1)
+        augment.freeze_parameters()
+        shifted_samples1 = augment(samples1, sample_rate_1)
+        shifted_samples2 = augment(samples2, sample_rate_2)
+
+        num_samples1_shifted = np.count_nonzero(shifted_samples1 == 0)
+        num_samples2_shifted = np.count_nonzero(shifted_samples2 == 0)
+
+        assert num_samples1_shifted == 2
+        assert num_samples2_shifted == 4
+


### PR DESCRIPTION
This PR enables to freeze the Shift transform and then to use it on audio with different sample rates. As it was before, the `num_places_to_shift` would still be the same after freezing the parameters no matter the sample rate.