### PR TITLE
Raise exception instead of warning when multichannel audio has wrong shape

### DIFF
--- a/audiomentations/core/transforms_interface.py
+++ b/audiomentations/core/transforms_interface.py
@@ -17,6 +17,10 @@ class MonoAudioNotSupportedException(Exception):
     pass
 
 
+class WrongMultichannelAudioShape(Exception):
+    pass
+
+
 class BaseTransform:
     supports_mono = True
     supports_multichannel = False
@@ -63,10 +67,10 @@ class BaseWaveformTransform(BaseTransform):
         if self.parameters["should_apply"] and len(samples) > 0:
             if self.is_multichannel(samples):
                 if samples.shape[0] > samples.shape[1]:
-                    warnings.warn(
+                    raise WrongMultichannelAudioShape(
                         "Multichannel audio must have channels first, not channels last. In"
                         " other words, the shape must be (channels, samples), not"
-                        " (samples, channels)"
+                        " (samples, channels). See https://iver56.github.io/audiomentations/guides/multichannel_audio_array_shapes/ for more info."
                     )
                 if not self.supports_multichannel:
                     raise MultichannelAudioNotSupportedException(

--- a/docs/guides/multichannel_audio_array_shapes.md
+++ b/docs/guides/multichannel_audio_array_shapes.md
@@ -6,7 +6,7 @@ When working with audio files in Python, you may encounter two main formats for 
 
 This format has the shape `(channels, samples)`. In the context of a stereo audio file, the number of channels would be 2 (for left and right), and samples are the individual data points in the audio file. For example, a stereo audio file with a duration of 1 second sampled at 44100 Hz would have a shape of `(2, 44100)`.
 
-This is the format expected by the `audiomentations` library when dealing with multichannel audio. If you provide multichannel audio data in a different format, you'll receive a warning.
+This is the format expected by the `audiomentations` library when dealing with multichannel audio. If you provide multichannel audio data in a different format, a `WrongMultichannelAudioShape` exception will be raised.
 
 Note that `audiomentations` also supports mono audio, i.e. shape like `(1, samples)` or `(samples,)`
 

--- a/tests/test_gain.py
+++ b/tests/test_gain.py
@@ -1,9 +1,11 @@
 import warnings
 
 import numpy as np
+import pytest
 from numpy.testing import assert_almost_equal
 
 from audiomentations import Gain
+from audiomentations.core.transforms_interface import WrongMultichannelAudioShape
 
 
 class TestGain:
@@ -52,11 +54,5 @@ class TestGain:
 
         augment = Gain(min_gain_in_db=-6, max_gain_in_db=-6, p=1.0)
 
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
+        with pytest.raises(WrongMultichannelAudioShape):
             processed_samples = augment(samples=samples, sample_rate=sample_rate)
-
-            assert len(w) == 1
-            assert "Multichannel audio must have channels first" in str(w[-1].message)


### PR DESCRIPTION
https://github.com/iver56/audiomentations/issues/274