### PR TITLE
Add 'res_type' argument for performance of PitchShift

### DIFF
--- a/audiomentations/augmentations/pitch_shift.py
+++ b/audiomentations/augmentations/pitch_shift.py
@@ -13,7 +13,7 @@ class PitchShift(BaseWaveformTransform):
     supports_multichannel = True
 
     def __init__(
-        self, min_semitones: float = -4.0, max_semitones: float = 4, p: float = 0.5
+        self, min_semitones: float = -4.0, max_semitones: float = 4, res_type: str = "soxr_hq", p: float = 0.5
     ):
         """
         :param min_semitones: Minimum semitones to shift. Negative number means shift down.
@@ -26,6 +26,7 @@ class PitchShift(BaseWaveformTransform):
         assert min_semitones <= max_semitones
         self.min_semitones = min_semitones
         self.max_semitones = max_semitones
+        self.res_type = res_type
 
     def randomize_parameters(self, samples: np.ndarray, sample_rate: int):
         super().randomize_parameters(samples, sample_rate)
@@ -54,6 +55,7 @@ class PitchShift(BaseWaveformTransform):
                     pitch_shifted_samples[i],
                     sr=sample_rate,
                     n_steps=self.parameters["num_semitones"],
+                    res_type=self.res_type,
                 )
 
         return pitch_shifted_samples


### PR DESCRIPTION
Current `PitchShift` augmentation would only use the "soxr_hq" resampler (default sampler of `librosa.effect.pitch_shift`). But this default resampler is too slow. In real scenarios, we usually use a faster "polyphase" or "linear" resampler. So we need to add a new argument to let `PitchShift` choose a resampler.

Here is the test code for performance improvement:
```
import time
import numpy as np

from audiomentations import Compose, AddGaussianNoise, AddGaussianSNR, TimeStretch, PitchShift

sound = np.random.rand(32000*10).astype(np.float32)

augment = Compose([
	PitchShift(min_semitones=-5, max_semitones=5, p=1.0)
])
begin = time.time()
output = augment(samples=sound, sample_rate=32000)
print("time:", time.time() - begin)

augment = Compose([
	PitchShift(min_semitones=-5, max_semitones=5, res_type="linear", p=1.0)
])
begin = time.time()
output = augment(samples=sound, sample_rate=32000)
print("time(linear):", time.time() - begin)
```