### PR TITLE
Improve Shift

### DIFF
--- a/audiomentations/augmentations/shift.py
+++ b/audiomentations/augmentations/shift.py
@@ -28,8 +28,8 @@ class Shift(BaseWaveformTransform):
         p: float = 0.5,
     ):
         """
-        :param min_shift: minimum amount of shifting in time. See also shift_unit.
-        :param max_shift: maximum amount of shifting in time. See also shift_unit.
+        :param min_shift: Minimum amount of shifting in time. See also shift_unit.
+        :param max_shift: Maximum amount of shifting in time. See also shift_unit.
         :param shift_unit: Defines the unit of the value of min_shift and max_shift.
             "fraction": Fraction of the total sound length
             "samples": Number of audio samples

--- a/audiomentations/augmentations/shift.py
+++ b/audiomentations/augmentations/shift.py
@@ -14,16 +14,21 @@ class Shift(BaseWaveformTransform):
 
     def __init__(
         self,
-        min_fraction: float = -0.5,
-        max_fraction: float = 0.5,
+        min_shift: float = -0.5,
+        max_shift: float = 0.5,
+        shift_unit: str = "fraction",
         rollover: bool = True,
-        fade: bool = False,
-        fade_duration: float = 0.01,
+        fade: bool = False,  # TODO: Remove this and let fade_duration=0.0 mean no fade
+        fade_duration: float = 0.01,  # TODO: Consider reducing this to 0.005 after I switched to the smoother fade
         p: float = 0.5,
     ):
         """
-        :param min_fraction: Minimum fraction of total sound length to shift
-        :param max_fraction: Maximum fraction of total sound length to shift
+        :param min_shift: minimum amount of shifting in time. See also shift_unit.
+        :param max_shift: maximum amount of shifting in time. See also shift_unit.
+        :param shift_unit: Defines the unit of the value of min_shift and max_shift.
+            "fraction": Fraction of the total sound length
+            "samples": Number of audio samples
+            "seconds": Number of seconds
         :param rollover: When set to True, samples that roll beyond the first or last position
             are re-introduced at the last or first. When set to False, samples that roll beyond
             the first or last position are discarded. In other words, rollover=False results in
@@ -36,12 +41,23 @@ class Shift(BaseWaveformTransform):
         :param p: The probability of applying this transform
         """
         super().__init__(p)
-        assert min_fraction >= -1
-        assert max_fraction <= 1
+
+        if min_shift > max_shift:
+            raise ValueError("min_shift must not be greater than max_shift")
+        if shift_unit not in ("fraction", "samples", "seconds"):
+            raise ValueError('shift_unit must be "fraction", "samples" or "seconds"')
+        if shift_unit == "fraction":
+            if min_shift < -1:
+                raise ValueError(
+                    'min_shift must be >= -1 when shift_unit is "fraction"'
+                )
+            if max_shift > 1:
+                raise ValueError('max_shift must be <= 1 when shift_unit is "fraction"')
         assert type(fade_duration) in [int, float] or not fade
         assert fade_duration > 0 or not fade
-        self.min_fraction = min_fraction
-        self.max_fraction = max_fraction
+        self.min_shift = min_shift
+        self.max_shift = max_shift
+        self.shift_unit = shift_unit
         self.rollover = rollover
         self.fade = fade
         self.fade_duration = fade_duration
@@ -49,14 +65,24 @@ class Shift(BaseWaveformTransform):
     def randomize_parameters(self, samples: np.ndarray, sample_rate: int):
         super().randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"]:
-            self.parameters["fraction_to_shift"] = random.uniform(
-                self.min_fraction, self.max_fraction
+            if self.shift_unit == "samples":
+                min_shift_in_samples = self.min_shift
+                max_shift_in_samples = self.max_shift
+            elif self.shift_unit == "fraction":
+                min_shift_in_samples = int(round(self.min_shift * samples.shape[-1]))
+                max_shift_in_samples = int(round(self.max_shift * samples.shape[-1]))
+            elif self.shift_unit == "seconds":
+                min_shift_in_samples = int(round(self.min_shift * sample_rate))
+                max_shift_in_samples = int(round(self.max_shift * sample_rate))
+            else:
+                raise ValueError("invalid shift_unit")
+
+            self.parameters["num_samples_to_shift"] = random.randint(
+                min_shift_in_samples, max_shift_in_samples
             )
 
     def apply(self, samples: np.ndarray, sample_rate: int):
-        num_places_to_shift = round(
-            self.parameters["fraction_to_shift"] * samples.shape[-1]
-        )
+        num_places_to_shift = self.parameters["num_samples_to_shift"]
         shifted_samples = np.roll(samples, num_places_to_shift, axis=-1)
 
         if not self.rollover:
@@ -68,11 +94,11 @@ class Shift(BaseWaveformTransform):
         if self.fade:
             fade_length = int(sample_rate * self.fade_duration)
 
+            # TODO: Use smooth fade!
             fade_in = np.linspace(0, 1, num=fade_length)
             fade_out = np.linspace(1, 0, num=fade_length)
 
             if num_places_to_shift > 0:
-
                 fade_in_start = num_places_to_shift
                 fade_in_end = min(
                     num_places_to_shift + fade_length, shifted_samples.shape[-1]
@@ -85,7 +111,6 @@ class Shift(BaseWaveformTransform):
                 ] *= fade_in[:fade_in_length]
 
                 if self.rollover:
-
                     fade_out_start = max(num_places_to_shift - fade_length, 0)
                     fade_out_end = num_places_to_shift
                     fade_out_length = fade_out_end - fade_out_start
@@ -95,7 +120,6 @@ class Shift(BaseWaveformTransform):
                     ]
 
             elif num_places_to_shift < 0:
-
                 positive_num_places_to_shift = (
                     shifted_samples.shape[-1] + num_places_to_shift
                 )

--- a/audiomentations/augmentations/shift.py
+++ b/audiomentations/augmentations/shift.py
@@ -6,6 +6,8 @@ import numpy as np
 from audiomentations.core.transforms_interface import BaseWaveformTransform
 
 # 0.00025 seconds corresponds to 2 samples at 8000 Hz
+from audiomentations.core.utils import get_crossfade_mask_pair
+
 DURATION_EPSILON = 0.00025
 
 
@@ -112,10 +114,7 @@ class Shift(BaseWaveformTransform):
 
         if self.fade:
             fade_length = int(sample_rate * self.fade_duration)
-
-            # TODO: Use smooth fade!
-            fade_in = np.linspace(0, 1, num=fade_length)
-            fade_out = np.linspace(1, 0, num=fade_length)
+            fade_in, fade_out = get_crossfade_mask_pair(fade_length)
 
             if num_places_to_shift > 0:
                 fade_in_start = num_places_to_shift

--- a/audiomentations/core/composition.py
+++ b/audiomentations/core/composition.py
@@ -64,7 +64,7 @@ class Compose(BaseCompose):
         AddGaussianNoise(min_amplitude=0.001, max_amplitude=0.015, p=0.5),
         TimeStretch(min_rate=0.8, max_rate=1.25, p=0.5),
         PitchShift(min_semitones=-4, max_semitones=4, p=0.5),
-        Shift(min_fraction=-0.5, max_fraction=0.5, p=0.5),
+        Shift(min_shift=-0.5, max_shift=0.5, p=0.5),
     ])
 
     # Generate 2 seconds of dummy audio for the sake of example

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -381,12 +381,12 @@ if __name__ == "__main__":
             "name": "SevenBandParametricEQ",
         },
         {
-            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade=False, p=1.0),
+            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade_duration=0.0, p=1.0),
             "num_runs": 5,
             "name": "ShiftWithoutFade",
         },
         {
-            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade=True, p=1.0),
+            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade_duration=0.01, p=1.0),
             "num_runs": 5,
             "name": "ShiftWithShortFade",
         },
@@ -395,7 +395,6 @@ if __name__ == "__main__":
                 min_shift=-0.5,
                 max_shift=0.5,
                 rollover=False,
-                fade=True,
                 fade_duration=0.3,
                 p=1.0,
             ),

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -381,19 +381,19 @@ if __name__ == "__main__":
             "name": "SevenBandParametricEQ",
         },
         {
-            "instance": Shift(min_fraction=-0.5, max_fraction=0.5, fade=False, p=1.0),
+            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade=False, p=1.0),
             "num_runs": 5,
             "name": "ShiftWithoutFade",
         },
         {
-            "instance": Shift(min_fraction=-0.5, max_fraction=0.5, fade=True, p=1.0),
+            "instance": Shift(min_shift=-0.5, max_shift=0.5, fade=True, p=1.0),
             "num_runs": 5,
             "name": "ShiftWithShortFade",
         },
         {
             "instance": Shift(
-                min_fraction=-0.5,
-                max_fraction=0.5,
+                min_shift=-0.5,
+                max_shift=0.5,
                 rollover=False,
                 fade=True,
                 fade_duration=0.3,
@@ -417,7 +417,7 @@ if __name__ == "__main__":
                             PitchShift(min_semitones=-4, max_semitones=4, p=1.0),
                         ],
                     ),
-                    Shift(min_fraction=-0.5, max_fraction=0.5, p=0.5),
+                    Shift(min_shift=-0.5, max_shift=0.5, p=0.5),
                     OneOf([TanhDistortion(p=1.0), ClippingDistortion(p=1.0)], p=0.25),
                 ]
             ),

--- a/demo/generate_examples_for_doc.py
+++ b/demo/generate_examples_for_doc.py
@@ -406,7 +406,7 @@ class ShiftExample(TransformUsageExample):
     def generate_example(self):
         random.seed(345)
         np.random.seed(345)
-        transform = Shift(min_fraction=0.75, max_fraction=0.75, rollover=True, p=1)
+        transform = Shift(min_shift=0.75, max_shift=0.75, rollover=True, p=1)
 
         sound, sample_rate = load_sound_file(
             librosa.example("libri1"), sample_rate=16000

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+The `Shift` API has been changed:
+
+* Removed `fade` parameter. `fade_duration=0.0` now denotes disabled fading.
+* Rename `min_fraction` to `min_shift` and `max_fraction` to `max_shift`
+* Add `shift_unit` parameter
+* Smoother fade curve
+
+The following example shows how you can adapt your code when upgrading from <=v0.32.0 to >=v0.33.0:
+
+| <= 0.32.0 | >= 0.33.0                                                                         |
+| --------- |-----------------------------------------------------------------------------------|
+| `Shift(min_fraction=-0.5, max_fraction=0.5, fade=True, fade_duration=0.01)` | `Shift(min_shift=-0.5, max_shift=0.5, shift_unit="fraction", fade_duration=0.01)` |
+
 ## [0.32.0] - 2023-08-15
 
 ### Added

--- a/docs/waveform_transforms/shift.md
+++ b/docs/waveform_transforms/shift.md
@@ -4,16 +4,27 @@ _Added in v0.5.0_
 
 Shift the samples forwards or backwards, with or without rollover
 
-
 ## Shift API
 
-[`min_fraction`](#min_fraction){ #min_fraction }: `float` • range: [-1, 1]
-:   :octicons-milestone-24: Default: `-0.5`. Minimum fraction of total sound length to
-    shift.
+:information_source: This only applies to version 0.33.0 and newer. If you are using an older
+version, you should consider upgrading. Or if you really want to keep using the old
+version, you can check the ["Old Shift API (<=v0.32.0)" section](#old-shift-api-v0320) below
 
-[`max_fraction`](#max_fraction){ #max_fraction }: `float` • range: [-1, 1]
-:   :octicons-milestone-24: Default: `0.5`. Maximum fraction of total sound length to
-    shift.
+[`min_shift`](#min_shift){ #min_shift }: `float | int`
+:   :octicons-milestone-24: Default: `-0.5`. Minimum amount of shifting in time. See also
+    [`shift_unit`](#shift_unit).
+
+[`max_shift`](#max_shift){ #max_shift }: `float | int`
+:   :octicons-milestone-24: Default: `0.5`. Maximum amount of shifting in time. See also
+    [`shift_unit`](#shift_unit).
+
+[`shift_unit`](#shift_unit){ #shift_unit }: `str` • choices: `"fraction"`, `"samples"`, `"seconds"`
+:   :octicons-milestone-24: Default: `"fraction"` Defines the unit of the value of
+    [`min_shift`](#min_shift) and [`max_shift`](#max_shift).
+
+    * `"fraction"`: Fraction of the total sound length
+    * `"samples"`: Number of audio samples
+    * `"seconds"`: Number of seconds
 
 [`rollover`](#rollover){ #rollover }: `bool`
 :   :octicons-milestone-24: Default: `True`. When set to `True`, samples that roll
@@ -21,15 +32,44 @@ Shift the samples forwards or backwards, with or without rollover
     to `False`, samples that roll beyond the first or last position are discarded. In
     other words, `rollover=False` results in an empty space (with zeroes).
 
-[`fade`](#fade){ #fade }: `bool`
+[`fade_duration`](#fade_duration){ #fade_duration }: `float` • unit: seconds • range: 0.0 or [0.00025, ∞)
+:   :octicons-milestone-24: Default: `0.005`. If you set this to a positive number,
+    there will be a fade in and/or out at the "stitch" (that was the start or the end
+    of the audio before the shift). This can smooth out an unwanted abrupt
+    change between two consecutive samples (which sounds like a
+    transient/click/pop). This parameter denotes the duration of the fade in
+    seconds. To disable the fading feature, set this parameter to 0.0.
+
+[`p`](#p){ #p }: `float` • range: [0.0, 1.0]
+:   :octicons-milestone-24: Default: `0.5`. The probability of applying this transform.
+
+## Old Shift API (<=v0.32.0)
+
+:warning: This only applies to version 0.32.0 and older
+
+`min_fraction`: `float` • range: [-1, 1]
+:   :octicons-milestone-24: Default: `-0.5`. Minimum fraction of total sound length to
+    shift.
+
+`max_fraction`: `float` • range: [-1, 1]
+:   :octicons-milestone-24: Default: `0.5`. Maximum fraction of total sound length to
+    shift.
+
+`rollover`: `bool`
+:   :octicons-milestone-24: Default: `True`. When set to `True`, samples that roll
+    beyond the first or last position are re-introduced at the last or first. When set
+    to `False`, samples that roll beyond the first or last position are discarded. In
+    other words, `rollover=False` results in an empty space (with zeroes).
+
+`fade`: `bool`
 :   :octicons-milestone-24: Default: `False`. When set to `True`, there will be a short
     fade in and/or out at the "stitch" (that was the start or the end of the audio
     before the shift). This can smooth out an unwanted abrupt change between two
     consecutive samples (which sounds like a transient/click/pop).
 
-[`fade_duration`](#fade_duration){ #fade_duration }: `float` • unit: seconds
+`fade_duration`: `float` • unit: seconds
 :   :octicons-milestone-24: Default: `0.01`. If `fade=True`, then this is the duration
     of the fade in seconds.
 
-[`p`](#p){ #p }: `float` • range: [0.0, 1.0]
+`p`: `float` • range: [0.0, 1.0]
 :   :octicons-milestone-24: Default: `0.5`. The probability of applying this transform.

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -54,7 +54,7 @@ class TestCompose:
                 ),
                 ClippingDistortion(p=0.5),
                 TimeMask(min_band_part=0.2, max_band_part=0.5, p=0.5),
-                Shift(min_fraction=0.5, max_fraction=0.5, p=0.5),
+                Shift(min_shift=0.5, max_shift=0.5, p=0.5),
             ]
         )
         augmenter.freeze_parameters()

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -99,7 +99,7 @@ class TestOneOf:
                 ),
                 ClippingDistortion(p=1.0),
                 TimeMask(min_band_part=0.2, max_band_part=0.5, p=1.0),
-                Shift(min_fraction=0.5, max_fraction=0.5, p=1.0),
+                Shift(min_shift=0.5, max_shift=0.5, p=1.0),
             ]
         )
         augmenter.freeze_parameters()

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -6,7 +6,7 @@ from audiomentations import Shift
 
 
 class TestShift:
-    def test_shift(self):
+    def test_shift_fraction(self):
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
         sample_rate = 16000
 
@@ -33,6 +33,38 @@ class TestShift:
             np.array([0.5, 0.25, 0.125, 1.0], dtype=np.float32),
         )
         assert backward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
+
+    def test_shift_samples(self):
+        samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
+        sample_rate = 16000
+
+        forward_augmenter = Shift(
+            min_shift=1, max_shift=1, shift_unit="samples", fade_duration=0.0, p=1.0
+        )
+        forward_shifted_samples = forward_augmenter(
+            samples=samples, sample_rate=sample_rate
+        )
+        assert_almost_equal(
+            forward_shifted_samples, np.array([0.125, 1.0, 0.5, 0.25], dtype=np.float32)
+        )
+        assert forward_shifted_samples.dtype == np.float32
+        assert len(forward_shifted_samples) == 4
+
+    def test_shift_seconds(self):
+        samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
+        sample_rate = 2
+
+        forward_augmenter = Shift(
+            min_shift=1.0, max_shift=1.0, shift_unit="seconds", fade_duration=0.0, p=1.0
+        )
+        forward_shifted_samples = forward_augmenter(
+            samples=samples, sample_rate=sample_rate
+        )
+        assert_almost_equal(
+            forward_shifted_samples, np.array([0.25, 0.125, 1.0, 0.5], dtype=np.float32)
+        )
+        assert forward_shifted_samples.dtype == np.float32
         assert len(forward_shifted_samples) == 4
 
     def test_shift_without_rollover(self):

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from audiomentations import Shift, Compose
+from audiomentations import Shift
 
 
 class TestShift:
@@ -9,7 +9,9 @@ class TestShift:
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
         sample_rate = 16000
 
-        forward_augmenter = Compose([Shift(min_shift=0.5, max_shift=0.5, p=1.0)])
+        forward_augmenter = Shift(
+            min_shift=0.5, max_shift=0.5, fade_duration=0.0, p=1.0
+        )
         forward_shifted_samples = forward_augmenter(
             samples=samples, sample_rate=sample_rate
         )
@@ -19,7 +21,9 @@ class TestShift:
         assert forward_shifted_samples.dtype == np.float32
         assert len(forward_shifted_samples) == 4
 
-        backward_augmenter = Compose([Shift(min_shift=-0.25, max_shift=-0.25, p=1.0)])
+        backward_augmenter = Shift(
+            min_shift=-0.25, max_shift=-0.25, fade_duration=0.0, p=1.0
+        )
         backward_shifted_samples = backward_augmenter(
             samples=samples, sample_rate=sample_rate
         )
@@ -34,8 +38,8 @@ class TestShift:
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
         sample_rate = 16000
 
-        forward_augmenter = Compose(
-            [Shift(min_shift=0.5, max_shift=0.5, rollover=False, p=1.0)]
+        forward_augmenter = Shift(
+            min_shift=0.5, max_shift=0.5, rollover=False, fade_duration=0.0, p=1.0
         )
         forward_shifted_samples = forward_augmenter(
             samples=samples, sample_rate=sample_rate
@@ -46,8 +50,8 @@ class TestShift:
         assert forward_shifted_samples.dtype == np.float32
         assert len(forward_shifted_samples) == 4
 
-        backward_augmenter = Compose(
-            [Shift(min_shift=-0.25, max_shift=-0.25, rollover=False, p=1.0)]
+        backward_augmenter = Shift(
+            min_shift=-0.25, max_shift=-0.25, rollover=False, fade_duration=0.0, p=1.0
         )
         backward_shifted_samples = backward_augmenter(
             samples=samples, sample_rate=sample_rate
@@ -65,7 +69,7 @@ class TestShift:
         )
         sample_rate = 4000
 
-        augment = Shift(min_shift=0.5, max_shift=0.5, p=1.0)
+        augment = Shift(min_shift=0.5, max_shift=0.5, fade_duration=0.0, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
         assert_almost_equal(
@@ -83,7 +87,9 @@ class TestShift:
         )
         sample_rate = 4000
 
-        augment = Shift(min_shift=0.5, max_shift=0.5, rollover=False, p=1.0)
+        augment = Shift(
+            min_shift=0.5, max_shift=0.5, rollover=False, fade_duration=0.0, p=1.0
+        )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
         assert_almost_equal(

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -9,7 +9,7 @@ class TestShift:
         samples = np.array([1.0, 0.5, 0.25, 0.125], dtype=np.float32)
         sample_rate = 16000
 
-        forward_augmenter = Compose([Shift(min_fraction=0.5, max_fraction=0.5, p=1.0)])
+        forward_augmenter = Compose([Shift(min_shift=0.5, max_shift=0.5, p=1.0)])
         forward_shifted_samples = forward_augmenter(
             samples=samples, sample_rate=sample_rate
         )
@@ -20,7 +20,7 @@ class TestShift:
         assert len(forward_shifted_samples) == 4
 
         backward_augmenter = Compose(
-            [Shift(min_fraction=-0.25, max_fraction=-0.25, p=1.0)]
+            [Shift(min_shift=-0.25, max_shift=-0.25, p=1.0)]
         )
         backward_shifted_samples = backward_augmenter(
             samples=samples, sample_rate=sample_rate
@@ -37,7 +37,7 @@ class TestShift:
         sample_rate = 16000
 
         forward_augmenter = Compose(
-            [Shift(min_fraction=0.5, max_fraction=0.5, rollover=False, p=1.0)]
+            [Shift(min_shift=0.5, max_shift=0.5, rollover=False, p=1.0)]
         )
         forward_shifted_samples = forward_augmenter(
             samples=samples, sample_rate=sample_rate
@@ -49,7 +49,7 @@ class TestShift:
         assert len(forward_shifted_samples) == 4
 
         backward_augmenter = Compose(
-            [Shift(min_fraction=-0.25, max_fraction=-0.25, rollover=False, p=1.0)]
+            [Shift(min_shift=-0.25, max_shift=-0.25, rollover=False, p=1.0)]
         )
         backward_shifted_samples = backward_augmenter(
             samples=samples, sample_rate=sample_rate
@@ -67,7 +67,7 @@ class TestShift:
         )
         sample_rate = 4000
 
-        augment = Shift(min_fraction=0.5, max_fraction=0.5, p=1.0)
+        augment = Shift(min_shift=0.5, max_shift=0.5, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
         assert_almost_equal(
@@ -85,7 +85,7 @@ class TestShift:
         )
         sample_rate = 4000
 
-        augment = Shift(min_fraction=0.5, max_fraction=0.5, rollover=False, p=1.0)
+        augment = Shift(min_shift=0.5, max_shift=0.5, rollover=False, p=1.0)
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
         assert_almost_equal(
@@ -102,8 +102,8 @@ class TestShift:
         sample_rate = 4000
 
         augment = Shift(
-            min_fraction=0.5,
-            max_fraction=0.5,
+            min_shift=0.5,
+            max_shift=0.5,
             rollover=False,
             fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
@@ -127,8 +127,8 @@ class TestShift:
         sample_rate = 4000
 
         augment = Shift(
-            min_fraction=0.5,
-            max_fraction=0.5,
+            min_shift=0.5,
+            max_shift=0.5,
             rollover=True,
             fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
@@ -150,8 +150,8 @@ class TestShift:
         sample_rate = 4000
 
         augment = Shift(
-            min_fraction=-0.5,
-            max_fraction=-0.5,
+            min_shift=-0.5,
+            max_shift=-0.5,
             rollover=True,
             fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
@@ -174,8 +174,8 @@ class TestShift:
         sample_rate = 4000
 
         augment = Shift(
-            min_fraction=-0.5,
-            max_fraction=-0.5,
+            min_shift=-0.5,
+            max_shift=-0.5,
             rollover=True,
             fade=True,
             fade_duration=1.0,
@@ -202,7 +202,7 @@ class TestShift:
         sample_rate_2 = 2
 
         augment = Shift(
-            min_fraction=0.5, max_fraction=0.5, rollover=False, fade=False, p=1.0
+            min_shift=0.5, max_shift=0.5, rollover=False, fade=False, p=1.0
         )
         augment.randomize_parameters(samples1, sample_rate_1)
         augment.freeze_parameters()

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -259,3 +259,21 @@ class TestShift:
 
         assert num_samples1_shifted == 2
         assert num_samples2_shifted == 4
+
+    def test_invalid_parameters(self):
+        with pytest.raises(ValueError):
+            Shift(min_shift=-1.5)
+        with pytest.raises(ValueError):
+            Shift(min_shift=1.5)
+        with pytest.raises(ValueError):
+            Shift(max_shift=-1.5)
+        with pytest.raises(ValueError):
+            Shift(max_shift=1.5)
+        with pytest.raises(ValueError):
+            Shift(min_shift=0.2, max_shift=0.1)
+        with pytest.raises(ValueError):
+            Shift(fade_duration=0.000001)
+        with pytest.raises(ValueError):
+            Shift(fade_duration=-1337)
+        with pytest.raises(ValueError):
+            Shift(shift_unit="lightyears")

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_almost_equal
 
 from audiomentations import Shift
@@ -114,12 +115,12 @@ class TestShift:
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        assert_almost_equal(
-            processed_samples,
+        assert processed_samples == pytest.approx(
             np.array(
-                [[0.0, 0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 0.0, -1.0, -3.0]],
+                [[0.0, 0.0, 0.0, 1.4067, 3.0], [0.0, 0.0, 0.0, -1.4067, -3.0]],
                 dtype=np.float32,
             ),
+            abs=0.01,
         )
 
     def test_shift_fade_rollover(self):
@@ -137,12 +138,12 @@ class TestShift:
             p=1.0,
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
-        assert_almost_equal(
-            processed_samples,
+        assert processed_samples == pytest.approx(
             np.array(
-                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]],
+                [[2.81, 0.0, 0, 1.407, 3.0], [-2.81, 0.0, 0, -1.407, -3.0]],
                 dtype=np.float32,
             ),
+            abs=0.01,
         )
 
     def test_shift_fade_rollover_2(self):
@@ -160,12 +161,12 @@ class TestShift:
             p=1.0,
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
-        assert_almost_equal(
-            processed_samples,
+        assert processed_samples == pytest.approx(
             np.array(
-                [[3.0, 2.0, 0.0, 0.0, 1.0], [-3.0, -2.0, 0.0, -0.0, -1.0]],
+                [[3.0, 2.81, 0.0, 0.0, 1.407], [-3.0, -2.81, 0.0, -0.0, -1.407]],
                 dtype=np.float32,
             ),
+            abs=0.01,
         )
 
     def test_shift_fade_rollover_3(self):
@@ -183,12 +184,23 @@ class TestShift:
             p=1.0,
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
-        assert_almost_equal(
-            processed_samples,
+        assert processed_samples == pytest.approx(
             np.array(
                 [
-                    [0.0015004, 0.0010003, 0.0, 0.0, 0.0005001],
-                    [-0.0015004, -0.0010003, -0.0, -0.0, -0.0005001],
+                    [
+                        3.0023373e-06,
+                        1.0004364e-06,
+                        0.0000000e00,
+                        0.0000000e00,
+                        5.0030241e-07,
+                    ],
+                    [
+                        -3.0023373e-06,
+                        -1.0004364e-06,
+                        -0.0000000e00,
+                        -0.0000000e00,
+                        -5.0030241e-07,
+                    ],
                 ],
                 dtype=np.float32,
             ),

--- a/tests/test_shift.py
+++ b/tests/test_shift.py
@@ -19,9 +19,7 @@ class TestShift:
         assert forward_shifted_samples.dtype == np.float32
         assert len(forward_shifted_samples) == 4
 
-        backward_augmenter = Compose(
-            [Shift(min_shift=-0.25, max_shift=-0.25, p=1.0)]
-        )
+        backward_augmenter = Compose([Shift(min_shift=-0.25, max_shift=-0.25, p=1.0)])
         backward_shifted_samples = backward_augmenter(
             samples=samples, sample_rate=sample_rate
         )
@@ -105,7 +103,6 @@ class TestShift:
             min_shift=0.5,
             max_shift=0.5,
             rollover=False,
-            fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
             p=1.0,
         )
@@ -130,7 +127,6 @@ class TestShift:
             min_shift=0.5,
             max_shift=0.5,
             rollover=True,
-            fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
             p=1.0,
         )
@@ -138,7 +134,8 @@ class TestShift:
         assert_almost_equal(
             processed_samples,
             np.array(
-                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]], dtype=np.float32,
+                [[2.0, 0.0, 0, 1.0, 3.0], [-2.0, 0.0, 0, -1.0, -3.0]],
+                dtype=np.float32,
             ),
         )
 
@@ -153,7 +150,6 @@ class TestShift:
             min_shift=-0.5,
             max_shift=-0.5,
             rollover=True,
-            fade=True,
             fade_duration=0.00075,  # 0.00075 * 4000 = 3
             p=1.0,
         )
@@ -177,7 +173,6 @@ class TestShift:
             min_shift=-0.5,
             max_shift=-0.5,
             rollover=True,
-            fade=True,
             fade_duration=1.0,
             p=1.0,
         )
@@ -202,7 +197,7 @@ class TestShift:
         sample_rate_2 = 2
 
         augment = Shift(
-            min_shift=0.5, max_shift=0.5, rollover=False, fade=False, p=1.0
+            min_shift=0.5, max_shift=0.5, rollover=False, fade_duration=0.0, p=1.0
         )
         augment.randomize_parameters(samples1, sample_rate_1)
         augment.freeze_parameters()
@@ -214,4 +209,3 @@ class TestShift:
 
         assert num_samples1_shifted == 2
         assert num_samples2_shifted == 4
-

--- a/tests/test_some_of.py
+++ b/tests/test_some_of.py
@@ -174,7 +174,7 @@ class TestSomeOf:
                 ),
                 ClippingDistortion(p=1.0),
                 TimeMask(min_band_part=0.2, max_band_part=0.5, p=1.0),
-                Shift(min_fraction=0.5, max_fraction=0.5, p=1.0),
+                Shift(min_shift=0.5, max_shift=0.5, p=1.0),
             ],
         )
         augmenter.freeze_parameters()


### PR DESCRIPTION
* Add support for "seconds" and "samples" in addition to "fraction", just like in torch-audiomentations
* Remove `fade` parameter, and use `fade_duration=0` for disabling fading
* Switch from linear fade to a smoother fade curve to reduce unwanted artifacts
* Change the default fade duration, since the fade curve is smoother now

Breaking changes, I know. I didn't do the whole backwards compatibility dance this time because it would take a lot of extra time and clutter the code. audiomentations is still in alpha, so the API is technically not stable. I will document the API changes well in the changelog.

- [x] Update documentation