### PR TITLE
Optimize max abs calculations in terms of memory and speed

### DIFF
--- a/audiomentations/augmentations/limiter.py
+++ b/audiomentations/augmentations/limiter.py
@@ -6,7 +6,7 @@ import sys
 from numpy.typing import NDArray
 
 from audiomentations.core.transforms_interface import BaseWaveformTransform
-from audiomentations.core.utils import convert_decibels_to_amplitude_ratio
+from audiomentations.core.utils import convert_decibels_to_amplitude_ratio, get_max_abs_amplitude
 
 
 class Limiter(BaseWaveformTransform):
@@ -98,7 +98,7 @@ class Limiter(BaseWaveformTransform):
             self.parameters["delay"] = max(round(0.6 * attack_seconds * sample_rate), 1)
 
             threshold_factor = (
-                np.amax(np.abs(samples))
+                get_max_abs_amplitude(samples)
                 if self.threshold_mode == "relative_to_signal_peak"
                 else 1.0
             )

--- a/audiomentations/augmentations/mp3_compression.py
+++ b/audiomentations/augmentations/mp3_compression.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 
 from audiomentations.core.transforms_interface import BaseWaveformTransform
 from audiomentations.core.utils import (
-    convert_float_samples_to_int16,
+    convert_float_samples_to_int16, get_max_abs_amplitude,
 )
 
 
@@ -125,7 +125,7 @@ class Mp3Compression(BaseWaveformTransform):
         If the audio is too loud, gain it down to avoid distortion in the audio file to
         be encoded.
         """
-        greatest_abs_sample = np.amax(np.abs(samples))
+        greatest_abs_sample = get_max_abs_amplitude(samples)
         if greatest_abs_sample > 1.0:
             self.post_gain_factor = greatest_abs_sample
             samples = samples * (1.0 / greatest_abs_sample)

--- a/audiomentations/augmentations/normalize.py
+++ b/audiomentations/augmentations/normalize.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from audiomentations.core.transforms_interface import BaseWaveformTransform
+from audiomentations.core.utils import get_max_abs_amplitude
 
 
 class Normalize(BaseWaveformTransform):
@@ -21,7 +22,7 @@ class Normalize(BaseWaveformTransform):
     def randomize_parameters(self, samples: NDArray[np.float32], sample_rate: int):
         super().randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"]:
-            self.parameters["max_amplitude"] = np.amax(np.abs(samples))
+            self.parameters["max_amplitude"] = get_max_abs_amplitude(samples)
 
     def apply(self, samples: NDArray[np.float32], sample_rate: int):
         if (

--- a/audiomentations/core/utils.py
+++ b/audiomentations/core/utils.py
@@ -5,6 +5,7 @@ from typing import List, Union, Tuple
 
 import math
 import numpy as np
+from numpy.typing import NDArray
 
 SUPPORTED_EXTENSIONS = (
     ".aac",
@@ -188,3 +189,10 @@ def get_crossfade_mask_pair(
     fade_in = c * c
     fade_out = d * d
     return fade_in, fade_out
+
+
+def get_max_abs_amplitude(samples: NDArray):
+    min_amplitude = np.amin(samples)
+    max_amplitude = np.amax(samples)
+    max_abs_amplitude = max(abs(min_amplitude), abs(max_amplitude))
+    return max_abs_amplitude

--- a/demo/generate_examples_for_doc.py
+++ b/demo/generate_examples_for_doc.py
@@ -52,6 +52,7 @@ from audiomentations import (
     AddGaussianSNR,
 )
 from audiomentations.core.audio_loading_utils import load_sound_file
+from audiomentations.core.utils import get_max_abs_amplitude
 
 DEMO_DIR = os.path.dirname(__file__)
 transform_usage_example_classes = dict()
@@ -61,7 +62,10 @@ def plot_waveforms_and_spectrograms(
     sound, transformed_sound, sample_rate, output_file_path
 ):
     xmax = max(sound.shape[0], transformed_sound.shape[0])
-    ylim = max(np.amax(np.abs(sound)), np.amax(np.abs(transformed_sound))) * 1.1
+    ylim = (
+        max(get_max_abs_amplitude(sound), get_max_abs_amplitude(transformed_sound))
+        * 1.1
+    )
     sound = sound[:xmax]
     transformed_sound = transformed_sound[:xmax]
     fig, axs = plt.subplots(

--- a/tests/test_post_gain.py
+++ b/tests/test_post_gain.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 
 from audiomentations import Gain
 from audiomentations.core.post_gain import PostGain
-from audiomentations.core.utils import calculate_rms
+from audiomentations.core.utils import calculate_rms, get_max_abs_amplitude
 
 
 class TestPostGain:
@@ -52,7 +52,7 @@ class TestPostGain:
         )
         processed_samples = augment(samples=samples, sample_rate=sample_rate)
 
-        assert np.amax(np.abs(processed_samples)) == pytest.approx(1.0)
+        assert get_max_abs_amplitude(processed_samples) == pytest.approx(1.0)
         assert processed_samples.dtype == np.float32
 
     def test_peak_normalize_if_too_loud(self):


### PR DESCRIPTION
This way of computing the minmax is roughly 3x faster and uses less memory because it doesn't allocate memory for a new audio ndarray