### PR TITLE
Make test_simulate_apply_parity more lenient…

### DIFF
--- a/tests/test_room_simulator.py
+++ b/tests/test_room_simulator.py
@@ -40,7 +40,9 @@ class TestRoomSimulatorTransform:
             np.float32
         ).flatten()
 
-        assert np.all(augmented_samples_apply == augmented_samples_simulate)
+        assert pytest.approx(
+            augmented_samples_apply, augmented_samples_simulate, abs=1e-15
+        )
 
     def test_failing_case(self):
         """Failed case which identified a bug where the room created was not rectangular"""


### PR DESCRIPTION
…to avoid spurious test failure in some environments

The absolute error that led to the reported test failure in #317 was between ~8.88e-16 and 3.55e-15