### PR TITLE
Make RMS calculations faster by using numpy-rms

### DIFF
--- a/audiomentations/augmentations/tanh_distortion.py
+++ b/audiomentations/augmentations/tanh_distortion.py
@@ -47,7 +47,7 @@ class TanhDistortion(BaseWaveformTransform):
     def apply(self, samples: NDArray[np.float32], sample_rate: int):
         # Find out how much to pre-gain the audio to get a given amount of distortion
         percentile = 100 - 99 * self.parameters["distortion_amount"]
-        threshold = np.percentile(abs(samples), percentile)
+        threshold = np.percentile(np.abs(samples), percentile)
         gain_factor = 0.5 / (threshold + 1e-6)
 
         # Distort the audio

--- a/audiomentations/core/utils.py
+++ b/audiomentations/core/utils.py
@@ -5,6 +5,7 @@ from typing import List, Union, Tuple
 
 import math
 import numpy as np
+import numpy_rms
 from numpy.typing import NDArray
 
 SUPPORTED_EXTENSIONS = (
@@ -80,7 +81,7 @@ def find_audio_files_in_paths(
 
 def calculate_rms(samples):
     """Given a numpy array of audio samples, return its Root Mean Square (RMS)."""
-    return np.sqrt(np.mean(np.square(samples)))
+    return np.mean(numpy_rms.rms(samples))
 
 
 def calculate_rms_without_silence(samples, sample_rate):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 audioread==2.1.9
 black
-coverage==7.3.4
+coverage==7.4.4
 cylimiter==0.3.0
 fast-align-audio==0.3.0
 lameenc==1.4.2
@@ -8,11 +8,12 @@ librosa==0.10.0.post2
 matplotlib>=3.0.0,<4
 numba==0.57.0
 numpy==1.23.0
+numpy-rms>=0.4.1,<1
 pydub==0.23.1
 pyloudnorm==0.1.0
 pyroomacoustics==0.7.3
-pytest==7.4.3
-pytest-cov==4.1.0
+pytest==7.4.4
+pytest-cov==5.0.0
 scipy>=1.4,<1.13
 soxr==0.3.5
 tqdm==4.31.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(exclude=["demo", "tests"]),
     install_requires=[
         "numpy>=1.21.0",
+        "numpy-rms>=0.4.1,<1",
         "librosa>=0.8.0,!=0.10.0,<0.11.0",
         "scipy>=1.4,<1.13",
         "soxr>=0.3.2,<1.0.0",

--- a/tests/test_add_background_noise.py
+++ b/tests/test_add_background_noise.py
@@ -11,141 +11,142 @@ from audiomentations import AddBackgroundNoise, Compose, Reverse
 from demo.demo import DEMO_DIR
 
 
-class TestAddBackgroundNoise:
-    def test_add_background_noise(self):
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
-        sample_rate = 44100
+def test_add_background_noise():
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
+    sample_rate = 44100
+    augmenter = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+        min_snr_db=15.0,
+        max_snr_db=35.0,
+        p=1.0,
+    )
+    samples_out = augmenter(samples=samples, sample_rate=sample_rate)
+    assert not np.allclose(samples, samples_out)
+    assert samples_out.dtype == np.float32
+
+    # test old API
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
+    sample_rate = 44100
+    with pytest.warns(DeprecationWarning):
         augmenter = AddBackgroundNoise(
             sounds_path=os.path.join(DEMO_DIR, "background_noises"),
-            min_snr_db=15.0,
-            max_snr_db=35.0,
+            min_snr_in_db=15,
+            max_snr_in_db=35,
             p=1.0,
         )
-        samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        assert not np.allclose(samples, samples_out)
-        assert samples_out.dtype == np.float32
+    samples_out = augmenter(samples=samples, sample_rate=sample_rate)
+    assert not np.allclose(samples, samples_out)
+    assert samples_out.dtype == np.float32
 
-        # test old API
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
-        sample_rate = 44100
-        with pytest.warns(DeprecationWarning):
-            augmenter = AddBackgroundNoise(
-                sounds_path=os.path.join(DEMO_DIR, "background_noises"),
-                min_snr_in_db=15,
-                max_snr_in_db=35,
-                p=1.0,
-            )
-        samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        assert not np.allclose(samples, samples_out)
-        assert samples_out.dtype == np.float32
 
-    def test_pass_both_old_and_new_args(self):
-        with pytest.raises(ValueError):
-            AddBackgroundNoise(
-                sounds_path=os.path.join(DEMO_DIR, "background_noises"),
-                min_snr_db=15,
-                max_snr_db=35,
-                min_snr_in_db=15,
-                max_snr_in_db=35,
-            )
-
-    def test_add_background_noise_when_noise_sound_is_too_short(self):
-        sample_rate = 44100
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 14 * sample_rate)).astype(
-            np.float32
-        )
-        augmenter = AddBackgroundNoise(
+def test_pass_both_old_and_new_args():
+    with pytest.raises(ValueError):
+        AddBackgroundNoise(
             sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+            min_snr_db=15,
+            max_snr_db=35,
+            min_snr_in_db=15,
+            max_snr_in_db=35,
+        )
+
+
+def test_add_background_noise_when_noise_sound_is_too_short():
+    sample_rate = 44100
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 14 * sample_rate)).astype(
+        np.float32
+    )
+    augmenter = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+        min_snr_db=15,
+        max_snr_db=35,
+        p=1.0,
+    )
+    samples_out = augmenter(samples=samples, sample_rate=sample_rate)
+    assert not np.allclose(samples, samples_out)
+    assert samples_out.dtype == np.float32
+
+
+def test_try_add_almost_silent_file():
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 30000)).astype(np.float32)
+    sample_rate = 48000
+    augmenter = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "almost_silent"),
+        min_snr_db=15,
+        max_snr_db=35,
+        p=1.0,
+    )
+    samples_out = augmenter(samples=samples, sample_rate=sample_rate)
+    assert not np.allclose(samples, samples_out)
+    assert samples_out.dtype == np.float32
+
+
+def test_try_add_digital_silence():
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 40000)).astype(np.float32)
+    sample_rate = 48000
+    augmenter = Compose([
+        AddBackgroundNoise(
+            sounds_path=os.path.join(DEMO_DIR, "digital_silence"),
             min_snr_db=15,
             max_snr_db=35,
             p=1.0,
         )
+    ])
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
         samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        assert not np.allclose(samples, samples_out)
-        assert samples_out.dtype == np.float32
 
-    def test_try_add_almost_silent_file(self):
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 30000)).astype(np.float32)
-        sample_rate = 48000
-        augmenter = AddBackgroundNoise(
-            sounds_path=os.path.join(DEMO_DIR, "almost_silent"),
-            min_snr_db=15,
-            max_snr_db=35,
-            p=1.0,
-        )
-        samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        assert not np.allclose(samples, samples_out)
-        assert samples_out.dtype == np.float32
+        assert "is too silent to be added as noise" in str(w[-1].message)
 
-    def test_try_add_digital_silence(self):
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 40000)).astype(np.float32)
-        sample_rate = 48000
-        augmenter = Compose(
-            [
-                AddBackgroundNoise(
-                    sounds_path=os.path.join(DEMO_DIR, "digital_silence"),
-                    min_snr_db=15,
-                    max_snr_db=35,
-                    p=1.0,
-                )
-            ]
-        )
+    assert np.allclose(samples, samples_out)
+    assert samples_out.dtype == np.float32
 
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            samples_out = augmenter(samples=samples, sample_rate=sample_rate)
 
-            assert "is too silent to be added as noise" in str(w[-1].message)
+def test_serialize_parameters():
+    transform = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"), p=1.0
+    )
+    samples = np.random.normal(0, 1, size=1024).astype(np.float32)
+    transform.randomize_parameters(samples, sample_rate=44100)
+    json.dumps(transform.serialize_parameters())
 
-        assert np.allclose(samples, samples_out)
-        assert samples_out.dtype == np.float32
 
-    def test_serialize_parameters(self):
-        transform = AddBackgroundNoise(
-            sounds_path=os.path.join(DEMO_DIR, "background_noises"), p=1.0
-        )
-        samples = np.random.normal(0, 1, size=1024).astype(np.float32)
-        transform.randomize_parameters(samples, sample_rate=44100)
-        json.dumps(transform.serialize_parameters())
+def test_picklability():
+    transform = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"), p=1.0
+    )
+    pickled = pickle.dumps(transform)
+    unpickled = pickle.loads(pickled)
+    assert transform.sound_file_paths == unpickled.sound_file_paths
 
-    def test_picklability(self):
-        transform = AddBackgroundNoise(
-            sounds_path=os.path.join(DEMO_DIR, "background_noises"), p=1.0
-        )
-        pickled = pickle.dumps(transform)
-        unpickled = pickle.loads(pickled)
-        assert transform.sound_file_paths == unpickled.sound_file_paths
 
-    def test_absolute_option(self):
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
-        sample_rate = 44100
-        augmenter = AddBackgroundNoise(
-            sounds_path=os.path.join(DEMO_DIR, "background_noises"),
-            noise_rms="absolute",
-            p=1.0,
-        )
-        samples_out = augmenter(samples=samples, sample_rate=sample_rate)
-        assert not np.allclose(samples, samples_out)
+def test_absolute_option():
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
+    sample_rate = 44100
+    augmenter = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+        noise_rms="absolute",
+        p=1.0,
+    )
+    samples_out = augmenter(samples=samples, sample_rate=sample_rate)
+    assert not np.allclose(samples, samples_out)
 
-    def test_noise_transform(self):
-        np.random.seed(3650)
-        random.seed(3650)
-        samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
-        sample_rate = 44100
-        augmenter = AddBackgroundNoise(
-            sounds_path=os.path.join(DEMO_DIR, "background_noises"),
-            min_snr_db=3,
-            max_snr_db=6,
-            p=1.0,
-        )
-        samples_out_without_transform = augmenter(
-            samples=samples, sample_rate=sample_rate
-        )
-        augmenter.freeze_parameters()
-        augmenter.noise_transform = Reverse()
-        samples_out_with_transform = augmenter(samples=samples, sample_rate=sample_rate)
 
-        assert not np.allclose(
-            samples_out_without_transform, samples_out_with_transform
-        )
+def test_noise_transform():
+    np.random.seed(3650)
+    random.seed(3650)
+    samples = np.sin(np.linspace(0, 440 * 2 * np.pi, 22500)).astype(np.float32)
+    sample_rate = 44100
+    augmenter = AddBackgroundNoise(
+        sounds_path=os.path.join(DEMO_DIR, "background_noises"),
+        min_snr_db=3,
+        max_snr_db=6,
+        p=1.0,
+    )
+    samples_out_without_transform = augmenter(samples=samples, sample_rate=sample_rate)
+    augmenter.freeze_parameters()
+    augmenter.noise_transform = Reverse()
+    samples_out_with_transform = augmenter(samples=samples, sample_rate=sample_rate)
+
+    assert not np.allclose(samples_out_without_transform, samples_out_with_transform)

--- a/tests/test_tanh_distortion.py
+++ b/tests/test_tanh_distortion.py
@@ -5,33 +5,33 @@ from audiomentations import TanhDistortion
 from audiomentations.core.utils import calculate_rms
 
 
-class TestTanhDistortion:
-    def test_single_channel(self):
-        samples = np.random.normal(0, 0.1, size=(2048,)).astype(np.float32)
-        sample_rate = 16000
-        augmenter = TanhDistortion(min_distortion=0.2, max_distortion=0.6, p=1.0)
+def test_single_channel():
+    samples = np.random.normal(0, 0.1, size=(20480,)).astype(np.float32)
+    sample_rate = 16000
+    augmenter = TanhDistortion(min_distortion=0.2, max_distortion=0.6, p=1.0)
 
-        distorted_samples = augmenter(samples=samples, sample_rate=sample_rate)
+    distorted_samples = augmenter(samples=samples, sample_rate=sample_rate)
 
-        assert samples.dtype == distorted_samples.dtype
-        assert samples.shape == distorted_samples.shape
-        assert np.amax(distorted_samples) < np.amax(samples)
-        assert calculate_rms(distorted_samples) == pytest.approx(
-            calculate_rms(samples), abs=1e-3
+    assert samples.dtype == distorted_samples.dtype
+    assert samples.shape == distorted_samples.shape
+    assert np.amax(distorted_samples) < np.amax(samples)
+    assert calculate_rms(distorted_samples) == pytest.approx(
+        calculate_rms(samples), abs=1e-3
+    )
+
+
+def test_multichannel():
+    num_channels = 3
+    samples = np.random.normal(0, 0.1, size=(num_channels, 5555)).astype(np.float32)
+    sample_rate = 16000
+    augmenter = TanhDistortion(min_distortion=0.05, max_distortion=0.6, p=1.0)
+
+    distorted_samples = augmenter(samples=samples, sample_rate=sample_rate)
+
+    assert samples.dtype == distorted_samples.dtype
+    assert samples.shape == distorted_samples.shape
+    for i in range(num_channels):
+        assert not np.allclose(samples[i], distorted_samples[i])
+        assert calculate_rms(distorted_samples[i]) == pytest.approx(
+            calculate_rms(samples[i]), abs=1e-3
         )
-
-    def test_multichannel(self):
-        num_channels = 3
-        samples = np.random.normal(0, 0.1, size=(num_channels, 5555)).astype(np.float32)
-        sample_rate = 16000
-        augmenter = TanhDistortion(min_distortion=0.05, max_distortion=0.6, p=1.0)
-
-        distorted_samples = augmenter(samples=samples, sample_rate=sample_rate)
-
-        assert samples.dtype == distorted_samples.dtype
-        assert samples.shape == distorted_samples.shape
-        for i in range(num_channels):
-            assert not np.allclose(samples[i], distorted_samples[i])
-            assert calculate_rms(distorted_samples[i]) == pytest.approx(
-                calculate_rms(samples[i]), abs=1e-3
-            )


### PR DESCRIPTION
Speed up AddBackgroundNoise, AddColorNoise, AddGaussianSNR, AddShortNoises and TanhDistortion when processing mono audio. numpy-rms has not optimized processing of stereo/multichannel audio yet, although it works.

https://github.com/nomonosound/numpy-rms performs very fast RMS calculations, as it is written in C with SIMD optimizations. Compatibility is good, with support for Windows, macOS, musllinux, manylinux, Python 3.8-3.12, Arm, x86-64

For example, TanhDistortion becomes ~20% faster, and AddBackgroundNoise becomes up to ~70% faster