### PR TITLE
Make Mp3Compression slightly faster by replacing flatten with ravel

### DIFF
--- a/audiomentations/augmentations/mp3_compression.py
+++ b/audiomentations/augmentations/mp3_compression.py
@@ -188,7 +188,7 @@ class Mp3Compression(BaseWaveformTransform):
 
         if num_channels == 1:
             if int_samples.ndim == 1 and degraded_samples.ndim == 2:
-                degraded_samples = degraded_samples.flatten()
+                degraded_samples = np.ravel(degraded_samples)
             elif int_samples.ndim == 2 and degraded_samples.ndim == 1:
                 degraded_samples = degraded_samples.reshape((1, -1))
 
@@ -239,7 +239,7 @@ class Mp3Compression(BaseWaveformTransform):
 
         if num_channels == 1:
             if int_samples.ndim == 1 and degraded_samples.ndim == 2:
-                degraded_samples = degraded_samples.flatten()
+                degraded_samples = np.ravel(degraded_samples)
             elif int_samples.ndim == 2 and degraded_samples.ndim == 1:
                 degraded_samples = degraded_samples.reshape((1, -1))
 


### PR DESCRIPTION
Why? Because flatten() _always_ makes a copy of the array, which is not necessary/desired here. `ravel` only makes a copy if it is needed. Hence ravel is faster.