### PR TITLE
Fix a bug where AirAbsorption often chose the wrong humidity bucket

### DIFF
--- a/docs/waveform_transforms/air_absorption.md
+++ b/docs/waveform_transforms/air_absorption.md
@@ -18,7 +18,7 @@ It can also be seen as a lowpass filter with variable octave attenuation.
 Note that since this transform mostly affects high frequencies, it is only
 suitable for audio with sufficiently high sample rate, like 32 kHz and above.
 
-Note also that this transform only "simulates" the dampening of high frequencies, and
+Note also that this transform only "simulates" the damping of high frequencies, and
 does not attenuate according to the distance law. Gain augmentation needs to be done
 separately.
 

--- a/tests/test_air_absorption.py
+++ b/tests/test_air_absorption.py
@@ -1,3 +1,5 @@
+from audiomentations.augmentations.air_absorption import get_temperature_humidity_key
+
 DEBUG = False
 
 from audiomentations import AirAbsorption
@@ -14,32 +16,39 @@ def get_chirp_test(sample_rate, duration):
     return samples.astype(np.float32)
 
 
-class TestAirAbsorptionTransform:
-    @pytest.mark.parametrize("temperature", [10, 20])
-    @pytest.mark.parametrize("humidity", [30, 50, 70, 90])
-    @pytest.mark.parametrize("distance", [5, 10, 20, 100])
-    @pytest.mark.parametrize("sample_rate", [8000, 16000, 48000])
-    def test_input_shapes(self, temperature, humidity, distance, sample_rate):
-        np.random.seed(1)
+@pytest.mark.parametrize("temperature", [10, 20])
+@pytest.mark.parametrize("humidity", [30, 50, 70, 90])
+@pytest.mark.parametrize("distance", [5, 10, 20, 100])
+@pytest.mark.parametrize("sample_rate", [8000, 16000, 48000])
+def test_input_shapes(temperature, humidity, distance, sample_rate):
+    np.random.seed(1)
 
-        samples = get_chirp_test(sample_rate, 10)
+    samples = get_chirp_test(sample_rate, 10)
 
-        augment = AirAbsorption(
-            min_temperature=temperature,
-            max_temperature=temperature,
-            min_humidity=humidity,
-            max_humidity=humidity,
-            min_distance=distance,
-            max_distance=distance,
-        )
+    augment = AirAbsorption(
+        min_temperature=temperature,
+        max_temperature=temperature,
+        min_humidity=humidity,
+        max_humidity=humidity,
+        min_distance=distance,
+        max_distance=distance,
+    )
 
-        # Test 1D case
-        processed_samples = augment(samples, sample_rate=sample_rate)
-        assert processed_samples.shape == samples.shape
-        assert processed_samples.dtype == np.float32
+    # Test 1D case
+    processed_samples = augment(samples, sample_rate=sample_rate)
+    assert processed_samples.shape == samples.shape
+    assert processed_samples.dtype == np.float32
 
-        # Test 2D case
-        samples = np.tile(samples, (2, 1))
-        processed_samples = augment(samples, sample_rate=sample_rate)
-        assert processed_samples.shape == samples.shape
-        assert processed_samples.dtype == np.float32
+    # Test 2D case
+    samples = np.tile(samples, (2, 1))
+    processed_samples = augment(samples, sample_rate=sample_rate)
+    assert processed_samples.shape == samples.shape
+    assert processed_samples.dtype == np.float32
+
+def test_get_temperature_humidity_key():
+    assert get_temperature_humidity_key(10.0, 30.0) == "10C_30-50%"
+    assert get_temperature_humidity_key(10.0, 45.0) == "10C_30-50%"
+    assert get_temperature_humidity_key(10.0, 50.0) == "10C_30-50%"
+    assert get_temperature_humidity_key(10.0, 51.0) == "10C_50-70%"
+    assert get_temperature_humidity_key(10.0, 65.0) == "10C_50-70%"
+    assert get_temperature_humidity_key(20.0, 90.0) == "20C_70-90%"


### PR DESCRIPTION
Previously, it would always choose the 30-50% humidity bucket, due to an error in the logic