### PR TITLE
Fix an error when fade_length = 0.

### DIFF
--- a/audiomentations/augmentations/time_mask.py
+++ b/audiomentations/augmentations/time_mask.py
@@ -61,7 +61,8 @@ class TimeMask(BaseWaveformTransform):
         mask = np.zeros(t)
         if self.fade:
             fade_length = min(int(sample_rate * 0.01), int(t * 0.1))
-            mask[0:fade_length] = np.linspace(1, 0, num=fade_length)
-            mask[-fade_length:] = np.linspace(0, 1, num=fade_length)
+            if fade_length:
+                mask[0:fade_length] = np.linspace(1, 0, num=fade_length)
+                mask[-fade_length:] = np.linspace(0, 1, num=fade_length)
         new_samples[..., t0 : t0 + t] *= mask
         return new_samples


### PR DESCRIPTION
`int(t * 0.1)` may equal to 0.  In this case we skip fading, rather than raising an error.