### PR TITLE
Add optional weights argument to OneOf for weighted random selection

### DIFF
--- a/audiomentations/core/sampling.py
+++ b/audiomentations/core/sampling.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+class WeightedChoiceSampler:
+    """
+    A class for sampling from a weighted distribution using the cumulative distribution function (CDF).
+
+    Usage:
+    >>> sampler = WeightedChoiceSampler(weights=[0.2, 0.8])
+    >>> samples = sampler.sample(size=10)
+    """
+    def __init__(self, weights: list[float] = None):
+        assert weights is not None and len(weights) > 0, "Weights must be provided"
+
+        # ensure weights are normalized
+        weights = np.array(weights)
+        weights /= np.sum(weights)
+        assert np.all(weights >= 0), "Weights must be non-negative"
+
+        # initialize the sampler
+        self.num_transforms = len(weights)
+        self.cdf = np.cumsum(weights)
+        # Ensure the last element is exactly 1.0 due to potential floating point errors
+        self.cdf[-1] = 1.0
+
+    # Modified sample method to take size
+    def sample(self, size: int = 1) -> np.ndarray:
+        random_vals = np.random.rand(size)
+        # Use searchsorted with the array of random values
+        return np.searchsorted(self.cdf, random_vals, side='right')

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,9 @@ Same as Compose, but for spectrogram transforms
 
 ## `OneOf`
 
-OneOf randomly picks one of the given transforms when called, and applies that transform.
+OneOf randomly picks one of the given transforms when called, and applies that transform. 
+
+An optional `weights` list of floats may be given to guide the probability of each transform for being chosen. If not specified, a transform is chosen uniformly at random.
 
 ## `SomeOf`
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,139 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+
+from audiomentations.core.sampling import WeightedChoiceSampler
+
+
+class TestWeightedChoiceSampler:
+    def test_init_valid_weights(self):
+        weights = [0.2, 0.8]
+        sampler = WeightedChoiceSampler(weights=weights)
+        assert sampler.num_transforms == 2
+        assert_allclose(sampler.cdf, [0.2, 1.0])
+        assert sampler.cdf[-1] == 1.0  # Ensure last element is exactly 1.0
+
+    def test_init_valid_weights_needs_normalization(self):
+        weights = [1, 4] # Sums to 5
+        sampler = WeightedChoiceSampler(weights=weights)
+        assert sampler.num_transforms == 2
+        assert_allclose(sampler.cdf, [0.2, 1.0])
+        assert sampler.cdf[-1] == 1.0
+
+    def test_init_invalid_weights_none(self):
+        with pytest.raises(AssertionError, match="Weights must be provided"):
+            WeightedChoiceSampler(weights=None)
+
+    def test_init_invalid_weights_empty(self):
+        with pytest.raises(AssertionError, match="Weights must be provided"):
+            WeightedChoiceSampler(weights=[])
+
+    def test_init_invalid_weights_negative(self):
+        # WeightedChoiceSampler uses numpy's assert_all which raises AssertionError
+        with pytest.raises(AssertionError, match="Weights must be non-negative"):
+            WeightedChoiceSampler(weights=[0.5, -0.1])
+
+    def test_init_weights_all_zero(self):
+        # WeightedChoiceSampler checks for sum > 0 via division, leading to RuntimeWarning
+        # and then NaN values, which fail the non-negative check.
+        with pytest.raises(AssertionError, match="Weights must be non-negative"):
+            WeightedChoiceSampler(weights=[0.0, 0.0])
+
+    def test_sample_single(self):
+        weights = [0.1, 0.2, 0.7]
+        sampler = WeightedChoiceSampler(weights=weights)
+        sample_index = sampler.sample(size=1)[0]
+        assert 0 <= sample_index < 3
+
+    def test_sample_multiple(self):
+        weights = [0.1, 0.2, 0.7]
+        sampler = WeightedChoiceSampler(weights=weights)
+        sample_indices = sampler.sample(size=100)
+        assert len(sample_indices) == 100
+        assert all(0 <= idx < 3 for idx in sample_indices)
+
+    def test_sample_distribution(self):
+        weights = [0.1, 0.3, 0.6]
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 20000
+        sample_indices = sampler.sample(size=num_samples)
+
+        counts = np.bincount(sample_indices, minlength=len(weights))
+        observed_proportions = counts / num_samples
+
+        normalized_weights = np.array(weights) / np.sum(weights)
+
+        # Use a tolerance suitable for statistical tests
+        assert_allclose(observed_proportions, normalized_weights, atol=0.02)
+
+    def test_sample_edge_case_one_hot_first(self):
+        weights = [1.0, 0.0, 0.0]
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 100
+        sample_indices = sampler.sample(size=num_samples)
+        assert all(idx == 0 for idx in sample_indices)
+
+    def test_sample_edge_case_one_hot_middle(self):
+        weights = [0.0, 1.0, 0.0]
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 100
+        sample_indices = sampler.sample(size=num_samples)
+        assert all(idx == 1 for idx in sample_indices)
+
+    def test_sample_edge_case_uniform(self):
+        weights = [1.0, 1.0, 1.0]
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 30000
+        sample_indices = sampler.sample(size=num_samples)
+
+        counts = np.bincount(sample_indices, minlength=len(weights))
+        observed_proportions = counts / num_samples
+
+        expected_proportions = np.array([1/3, 1/3, 1/3])
+
+        assert_allclose(observed_proportions, expected_proportions, atol=0.02)
+
+    def test_sample_distribution_uniform(self):
+        # Use normalized weights for testing distribution
+        weights = np.array([0.5, 0.5])
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 10000
+        sample_indices = sampler.sample(size=num_samples)
+        
+        counts = np.bincount(sample_indices, minlength=sampler.num_transforms)
+        observed_proportions = counts / num_samples
+        
+        assert_allclose(observed_proportions, weights, atol=0.05)
+
+    def test_sample_distribution_non_uniform(self):
+         # Use normalized weights for testing distribution
+        weights = np.array([0.1, 0.7, 0.2])
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 20000
+        sample_indices = sampler.sample(size=num_samples)
+
+        counts = np.bincount(sample_indices, minlength=sampler.num_transforms)
+        observed_proportions = counts / num_samples
+        
+        assert_allclose(observed_proportions, weights, atol=0.05)
+
+    def test_sample_distribution_with_zero_weight(self):
+         # Use normalized weights for testing distribution
+        weights = np.array([0.5, 0.0, 0.5])
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 10000
+        sample_indices = sampler.sample(size=num_samples)
+
+        counts = np.bincount(sample_indices, minlength=sampler.num_transforms)
+        observed_proportions = counts / num_samples
+        
+        assert counts[1] == 0 # Index 1 should never be chosen
+        assert_allclose(observed_proportions, weights, atol=0.05)
+
+    def test_sample_single_weight(self):
+        weights = [1.0]
+        sampler = WeightedChoiceSampler(weights=weights)
+        num_samples = 100
+        sample_indices = sampler.sample(size=num_samples)
+        assert_array_equal(sample_indices, np.zeros(num_samples, dtype=int))
+        assert sampler.cdf[-1] == 1.0 


### PR DESCRIPTION
## Description

This addition should leave all existing scripts working the same, but allow for an optional argument for `OneOf` that allows weighted selection of the transform, instead of uniform random. 

If `weights` are not supplied, behavior will default to the way it has always been (uniform random), so this is fully backwards compatible :)

## Motivation

I have a large number of impulse response (IR) files that I wish to use at random in some augmentations for a model I am training, for example from my repo: [impulse-response-audio-files](https://github.com/worldveil/impulse-response-audio-files).

However, not all categories of these IRs are equally as important to our usecase, and as such, we'd like to upsample certain classes (ie: venues, large rooms), and downsample others (ie: small rooms, misc other IRs). 

## Example script

Let's envision a scenario in which we'd like to upsample one category 4x vs another (0.8 vs 0.2):

```python
from pathlib import Path
from collections import Counter

from audiomentations import Compose, ApplyImpulseResponse, OneOf
import numpy as np

# load some impulse responses from: https://github.com/worldveil/impulse-response-audio-files
IR_DIR = "./impulse-response-audio-files"
venues_dir1 = Path(IR_DIR) / "echo_thief" / "Venues"
misc_dir2 = Path(IR_DIR) / "voxengo"
weights = [0.8, 0.2]

augment = Compose([
    OneOf([
        ApplyImpulseResponse(ir_path=venues_dir1, p=1.0),
        ApplyImpulseResponse(ir_path=misc_dir2, p=1.0)
    ], p=0.5, weights=weights),
])

# Generate 2 seconds of dummy audio for the sake of example
samples = np.random.uniform(low=-0.2, high=0.2, size=(32000,)).astype(np.float32)

# let's count the number of times each transform is chosen to verify it's working
index_chosen = Counter()
one_of = augment.transforms[-1]

for i in range(1000):
    # Augment/transform/perturb the audio data
    augmented_samples = augment(samples=samples, sample_rate=44100)

    # roll the dice
    for i, transform in enumerate(augment.transforms):
        if i == len(augment.transforms) - 1:
            #print(f"We chose transform: {one_of.transforms[transform.transform_index].__class__}, which was index={transform.transform_index} (weights={one_of.weights})")
            index_chosen[transform.transform_index] += 1

# we should expect to see zero 4x as many times as 1
print(index_chosen)
```

For me, the output is:

```
Counter({0: 791, 1: 209})
```

which aligns with our expectation.

## Tests

Are all passing, with the exception of the two that depend on `fast-align-audio` which I wasn't able to install in the 30 min I had to make this PR :) but from quick glance this PR should not affect that functionality at all.