### PR TITLE
Ensure correct processing in TimeStretch and PitchShift with signalsmith_strech method…

### DIFF
--- a/audiomentations/augmentations/pitch_shift.py
+++ b/audiomentations/augmentations/pitch_shift.py
@@ -64,6 +64,13 @@ class PitchShift(BaseWaveformTransform):
             if original_ndim == 1:
                 samples = samples[np.newaxis, :]
 
+            if (
+                original_ndim == 2
+                and samples.shape[0] > 1
+                and not samples.flags.c_contiguous
+            ):
+                samples = np.ascontiguousarray(samples)
+
             stretch = python_stretch.Signalsmith.Stretch()
             stretch.preset(samples.shape[0], sample_rate)
             stretch.setTransposeSemitones(self.parameters["num_semitones"])

--- a/audiomentations/augmentations/time_stretch.py
+++ b/audiomentations/augmentations/time_stretch.py
@@ -19,7 +19,9 @@ class TimeStretch(BaseWaveformTransform):
         min_rate: float = 0.8,
         max_rate: float = 1.25,
         leave_length_unchanged: bool = True,
-        method: Literal["librosa_phase_vocoder", "signalsmith_stretch"] = "signalsmith_stretch",
+        method: Literal[
+            "librosa_phase_vocoder", "signalsmith_stretch"
+        ] = "signalsmith_stretch",
         p: float = 0.5,
     ):
         """
@@ -57,12 +59,21 @@ class TimeStretch(BaseWaveformTransform):
             """
             self.parameters["rate"] = random.uniform(self.min_rate, self.max_rate)
 
-    def apply(self, samples: NDArray[np.float32], sample_rate: int) -> NDArray[np.float32]:
+    def apply(
+        self, samples: NDArray[np.float32], sample_rate: int
+    ) -> NDArray[np.float32]:
         original_shape = samples.shape
         if self.method == "signalsmith_stretch":
             original_ndim = samples.ndim
             if original_ndim == 1:
                 samples = samples[np.newaxis, :]
+
+            if (
+                original_ndim == 2
+                and samples.shape[0] > 1
+                and not samples.flags.c_contiguous
+            ):
+                samples = np.ascontiguousarray(samples)
 
             stretch = python_stretch.Signalsmith.Stretch()
             stretch.preset(samples.shape[0], sample_rate)

--- a/tests/test_pitch_shift.py
+++ b/tests/test_pitch_shift.py
@@ -8,7 +8,7 @@ from audiomentations import PitchShift
 
 
 @pytest.mark.parametrize("method", ["librosa_phase_vocoder", "signalsmith_stretch"])
-def test_apply_pitch_shift_1dim(method):
+def test_1dim(method):
     samples = np.zeros((2048,), dtype=np.float32)
     sample_rate = 16000
     augmenter = PitchShift(min_semitones=-2, max_semitones=-1, method=method, p=1.0)
@@ -19,7 +19,7 @@ def test_apply_pitch_shift_1dim(method):
 
 
 @pytest.mark.parametrize("method", ["librosa_phase_vocoder", "signalsmith_stretch"])
-def test_apply_pitch_shift_multichannel(method):
+def test_multichannel(method):
     num_channels = 3
     samples = np.random.normal(0, 0.1, size=(num_channels, 5555)).astype(np.float32)
     sample_rate = 16000
@@ -30,6 +30,19 @@ def test_apply_pitch_shift_multichannel(method):
     assert samples_out.shape == samples.shape
     for i in range(num_channels):
         assert not np.allclose(samples[i], samples_out[i])
+
+
+def test_stereo_non_contiguous_ndarray():
+    num_channels = 2
+    samples = np.random.normal(0, 0.1, size=(5555, num_channels)).astype(np.float32)
+    sample_rate = 16000
+    augmenter = PitchShift(
+        min_semitones=1, max_semitones=2, method="signalsmith_stretch", p=1.0
+    )
+    samples_out = augmenter(samples=samples.T, sample_rate=sample_rate)
+
+    assert samples_out.dtype == np.float32
+    assert samples_out.shape == samples.T.shape
 
 
 def test_freeze_parameters():

--- a/tests/test_time_stretch.py
+++ b/tests/test_time_stretch.py
@@ -51,6 +51,24 @@ def test_multichannel(method):
         assert not np.allclose(samples[i], samples_out[i])
 
 
+def test_stereo_non_contiguous_ndarray():
+    num_channels = 2
+    samples = np.random.normal(0, 0.1, size=(5555, num_channels)).astype(np.float32)
+    sample_rate = 16000
+    augmenter = TimeStretch(
+        min_rate=0.8,
+        max_rate=0.9,
+        leave_length_unchanged=True,
+        method="signalsmith_stretch",
+        p=1.0,
+    )
+
+    samples_out = augmenter(samples=samples.T, sample_rate=sample_rate)
+
+    assert samples.dtype == samples_out.dtype
+    assert samples.T.shape == samples_out.shape
+
+
 def test_invalid_params():
     with pytest.raises(ValueError):
         TimeStretch(min_rate=0.0)


### PR DESCRIPTION
…even if the input ndarray is not C-contiguous.

Close #396