### PR TITLE
Loading RIR faster

### DIFF
--- a/audiomentations/augmentations/apply_impulse_response.py
+++ b/audiomentations/augmentations/apply_impulse_response.py
@@ -53,7 +53,7 @@ class ApplyImpulseResponse(BaseWaveformTransform):
     def randomize_parameters(self, samples: NDArray[np.float32], sample_rate: int):
         super().randomize_parameters(samples, sample_rate)
         if self.parameters["should_apply"]:
-            self.parameters["ir_file_path"] = random.choice(self.ir_files)            
+            self.parameters["ir_file_path"] = random.choice(self.ir_files)
 
     def apply(self, samples: NDArray[np.float32], sample_rate: int) -> NDArray[np.float32]:
         # Determine if the impulse response should be loaded as mono


### PR DESCRIPTION
This PR follows the approach in #360, removing the `lru_cache` from `apply_impulse_response` and truncating the RIR to the maximum length of the target audio.

In the case where the RIR would be longer than the audio and `leave_length_unchanged = False` the whole RIR is loaded.