### PR TITLE
Add shared audio cache to accelerate large, parallel jobs

### DIFF
--- a/audiomentations/__init__.py
+++ b/audiomentations/__init__.py
@@ -38,5 +38,10 @@ from .augmentations.time_mask import TimeMask
 from .augmentations.time_stretch import TimeStretch
 from .augmentations.trim import Trim
 from .core.composition import Compose, OneOf, SomeOf
+from .core.audio_loading_utils import (
+    set_audio_cache_backend,
+    get_audio_cache_backend,
+    clear_audio_cache_backend,
+)
 
 __version__ = "0.43.1"

--- a/audiomentations/core/audio_loading_utils.py
+++ b/audiomentations/core/audio_loading_utils.py
@@ -3,20 +3,57 @@ import librosa
 import numpy as np
 
 
-def load_sound_file(file_path, sample_rate, mono=True, resample_type="auto", offset = 0.0, duration = None):
-    """
-    Load an audio file as a floating point time series. Audio will be automatically
-    resampled to the given sample rate.
+# =============================================================================
+# Audio Cache Backend
+# =============================================================================
+# A cache backend with get/put interface for use with Ray Actors or similar.
+# The backend must implement:
+#   - get(key) -> np.ndarray or None
+#   - put(key, audio) -> None
+# Key format: (file_path, sample_rate, mono)
 
-    :param file_path: str or Path instance that points to a sound file
-    :param sample_rate: If not None, resample to this sample rate
-    :param mono: If True, mix any multichannel data down to mono, and return a 1D array
-    :param resample_type: "auto" means use "kaiser_fast" when upsampling and "kaiser_best" when
-        downsampling
+_audio_cache_backend = None
+
+
+def set_audio_cache_backend(backend):
     """
-    file_path = str(file_path)
+    Set a cache backend that load_sound_file() will use for caching audio.
+    
+    The backend must implement:
+        - get(key) -> np.ndarray or None
+        - put(key, audio) -> None
+    
+    Key format: (file_path: str, sample_rate: int, mono: bool)
+    
+    This enables mutable caching with LRU eviction, memory limits, etc.
+    For Ray, use an Actor that implements this interface.
+    
+    Args:
+        backend: Object with get/put methods, or None to disable.
+    """
+    global _audio_cache_backend
+    _audio_cache_backend = backend
+
+
+def get_audio_cache_backend():
+    """Get the current audio cache backend, or None if not set."""
+    return _audio_cache_backend
+
+
+def clear_audio_cache_backend():
+    """Clear the audio cache backend."""
+    global _audio_cache_backend
+    _audio_cache_backend = None
+
+
+# =============================================================================
+# Audio Loading
+# =============================================================================
+
+def _load_and_resample(file_path, sample_rate, mono, resample_type, offset=0.0, duration=None):
+    """Internal: load from disk and resample. Returns (samples, actual_sample_rate)."""
     samples, actual_sample_rate = librosa.load(
-        str(file_path), sr=None, mono=mono, dtype=np.float32, offset = offset, duration = duration
+        str(file_path), sr=None, mono=mono, dtype=np.float32, offset=offset, duration=duration
     )
 
     if sample_rate is not None and actual_sample_rate != sample_rate:
@@ -38,9 +75,54 @@ def load_sound_file(file_path, sample_rate, mono=True, resample_type="auto", off
                 str(file_path), actual_sample_rate, sample_rate
             )
         )
-
-    actual_sample_rate = actual_sample_rate if sample_rate is None else sample_rate
+        actual_sample_rate = sample_rate
 
     if mono:
         assert len(samples.shape) == 1
+    
     return samples, actual_sample_rate
+
+
+def _slice_audio(samples, sample_rate, offset, duration):
+    """Slice audio by offset/duration."""
+    if offset > 0.0 or duration is not None:
+        start_sample = int(offset * sample_rate)
+        if duration is not None:
+            end_sample = start_sample + int(duration * sample_rate)
+            return samples[..., start_sample:end_sample]
+        else:
+            return samples[..., start_sample:]
+    return samples
+
+
+def load_sound_file(file_path, sample_rate, mono=True, resample_type="auto", offset=0.0, duration=None):
+    """
+    Load an audio file as a floating point time series. Audio will be automatically
+    resampled to the given sample rate.
+
+    :param file_path: str or Path instance that points to a sound file
+    :param sample_rate: If not None, resample to this sample rate
+    :param mono: If True, mix any multichannel data down to mono, and return a 1D array
+    :param resample_type: "auto" means use "kaiser_fast" when upsampling and "kaiser_best" when
+        downsampling
+    """
+    file_path = str(file_path)
+    cache_key = (file_path, sample_rate, mono)
+    
+    # Check cache backend (mutable cache with get/put)
+    if _audio_cache_backend is not None:
+        cached = _audio_cache_backend.get(cache_key)
+        if cached is not None:
+            # Cache hit: slice and return
+            sliced = _slice_audio(cached, sample_rate, offset, duration)
+            return sliced.copy(), sample_rate
+        else:
+            # Cache miss: load FULL file, cache it, then slice
+            full_samples, actual_sr = _load_and_resample(file_path, sample_rate, mono, resample_type)
+            _audio_cache_backend.put(cache_key, full_samples)
+            sliced = _slice_audio(full_samples, actual_sr, offset, duration)
+            return sliced.copy(), actual_sr
+    
+    # No cache: load with offset/duration directly (more efficient for one-off loads)
+    samples, actual_sr = _load_and_resample(file_path, sample_rate, mono, resample_type, offset, duration)
+    return samples, actual_sr

--- a/docs/guides/shared_audio_cache.md
+++ b/docs/guides/shared_audio_cache.md
@@ -1,17 +1,28 @@
 # Audio Cache Backend
 
-Transforms like `AddBackgroundNoise` and `ApplyImpulseResponse` load audio files from disk and resample them on each use. Each transform has an LRU cache to avoid redundant loads within a single process.
+Transforms like `AddBackgroundNoise` and `ApplyImpulseResponse` load audio files from disk and resample them on each use.
 
-However, when processing large datasets with parallel workers, each worker starts with an empty cache. If you have `N` workers processing 10,000 audio files, the same impulse responses and background noises get loaded and resampled `N` times instead of once.
+When processing large datasets with parallel workers, each worker loads the same files independently. If you have `N` workers, the same impulse responses and background noises get loaded and resampled `N` times instead of once.
 
-The audio cache backend solves this by providing a shared mutable cache across workers. The example below uses Ray, which allows workers to share a cache actor. The cache populates on-demand as files are loaded (no pre-loading required) and uses LRU eviction when the memory limit is reached.
+The audio cache backend solves this by providing a shared mutable cache across workers that trades memory for processing time.
 
-## Usage with Ray
+## Example script
+
+This example uses Ray since its object store is a great fit for this usecase, but any backend as long as it implements the `get(key)`, `put(key, audio)` interface will work.
 
 ```python
+#!/usr/bin/env python
+"""Audio Cache Backend Benchmark"""
 import numpy as np
+import tempfile
+import time
+import shutil
+from pathlib import Path
+import soundfile as sf
 import ray
-from audiomentations import AddBackgroundNoise, set_audio_cache_backend
+
+from audiomentations import AddBackgroundNoise, set_audio_cache_backend, clear_audio_cache_backend
+
 
 @ray.remote
 class AudioCacheActor:
@@ -20,57 +31,118 @@ class AudioCacheActor:
     def __init__(self, max_memory_mb: float = 1000):
         self.cache = {}
         self.max_bytes = int(max_memory_mb * 1024 * 1024)
-        self.order = []  # LRU order
+        self.order = []
+        self.hits = 0
+        self.misses = 0
     
-    def get(self, key: tuple) -> np.ndarray | None:
+    def get(self, key):
         if key in self.cache:
             self.order.remove(key)
             self.order.append(key)
+            self.hits += 1
             return self.cache[key]
+        self.misses += 1
         return None
     
-    def put(self, key: tuple, audio: np.ndarray) -> None:
+    def put(self, key, audio):
         if key in self.cache:
             return
-        # Evict LRU until we have room
         while self._used() + audio.nbytes > self.max_bytes and self.order:
             del self.cache[self.order.pop(0)]
         self.cache[key] = audio
         self.order.append(key)
     
-    def _used(self) -> int:
+    def _used(self):
         return sum(v.nbytes for v in self.cache.values())
+    
+    def stats(self):
+        return {
+            'entries': len(self.cache),
+            'memory_mb': self._used() / 1024 / 1024,
+            'hits': self.hits,
+            'misses': self.misses,
+            'hit_rate': self.hits / (self.hits + self.misses) if (self.hits + self.misses) > 0 else 0,
+        }
 
 
 class RayAudioCacheBackend:
-    """Wrapper that adapts the Actor to the audiomentations interface."""
-    
     def __init__(self, actor):
         self.actor = actor
     
-    def get(self, key: tuple) -> np.ndarray | None:
+    def get(self, key):
         return ray.get(self.actor.get.remote(key))
     
-    def put(self, key: tuple, audio: np.ndarray) -> None:
-        self.actor.put.remote(key, audio)  # fire-and-forget
+    def put(self, key, audio):
+        ray.get(self.actor.put.remote(key, audio))
 
-
-# Usage
-ray.init()
-cache_actor = AudioCacheActor.remote(max_memory_mb=500)
 
 @ray.remote
-def process_audio(audio, noise_dir, cache_actor):
+def process_with_cache(audio, noise_dir, cache_actor):
     set_audio_cache_backend(RayAudioCacheBackend(cache_actor))
-    transform = AddBackgroundNoise(
-        sounds_path=noise_dir,
-        lru_cache_size=0,  # Disable per-transform cache; use shared backend only
-        p=1.0
-    )
+    transform = AddBackgroundNoise(sounds_path=str(noise_dir), p=1.0)
     return transform(audio, sample_rate=44100)
 
-futures = [process_audio.remote(audio, noise_dir, cache_actor) for audio in audio_list]
-results = ray.get(futures)
+
+@ray.remote
+def process_without_cache(audio, noise_dir):
+    clear_audio_cache_backend()
+    transform = AddBackgroundNoise(sounds_path=str(noise_dir), p=1.0)
+    return transform(audio, sample_rate=44100)
+
+
+if __name__ == "__main__":
+    # Generate test files
+    temp_dir = tempfile.mkdtemp()
+    noise_dir = Path(temp_dir) / "noise"
+    noise_dir.mkdir()
+
+    print("Generating 20 noise files @ 48000Hz...")
+    for i in range(20):
+        noise = np.random.randn(30 * 48000).astype(np.float32) * 0.1
+        sf.write(noise_dir / f"noise_{i:02d}.wav", noise, 48000)
+
+    input_audio = np.random.randn(5 * 44100).astype(np.float32)
+
+    ray.init(ignore_reinit_error=True)
+    cache_actor = AudioCacheActor.remote(max_memory_mb=500)
+
+    print("\nRunning 200 tasks WITHOUT cache...")
+    start = time.perf_counter()
+    ray.get([process_without_cache.remote(input_audio, str(noise_dir)) for _ in range(200)])
+    time_no_cache = time.perf_counter() - start
+
+    print("Running 200 tasks WITH cache...")
+    start = time.perf_counter()
+    ray.get([process_with_cache.remote(input_audio, str(noise_dir), cache_actor) for _ in range(200)])
+    time_with_cache = time.perf_counter() - start
+
+    stats = ray.get(cache_actor.stats.remote())
+
+    print(f"\n{'='*50}")
+    print(f"Without cache: {time_no_cache:.2f}s")
+    print(f"With cache:    {time_with_cache:.2f}s")
+    print(f"Speedup:       {time_no_cache/time_with_cache:.1f}x")
+    print(f"Cache:         {stats['entries']} files, {stats['memory_mb']:.0f} MB, {stats['hit_rate']:.0%} hit rate")
+    print(f"{'='*50}")
+
+    shutil.rmtree(temp_dir)
+    ray.shutdown()
+```
+
+Output:
+
+```
+Generating 20 noise files @ 48000Hz...
+
+Running 200 tasks WITHOUT cache...
+Running 200 tasks WITH cache...
+
+==================================================
+Without cache: 4.05s
+With cache:    0.37s
+Speedup:       11.1x
+Cache:         20 files, 101 MB, 73% hit rate
+==================================================
 ```
 
 ## Cache Key Format
@@ -84,34 +156,8 @@ All three must match for a cache hit.
 ## Cache Behavior
 
 - **Stores full files**: On cache miss, the full file is loaded and cached. Slicing for offset/duration happens on retrieval.
-- **LRU eviction**: When memory limit is reached, least recently used items are evicted
-- **No pre-loading**: Workers start immediately; cache warms up during processing
-
-## Disable Per-Transform LRU Cache
-
-Transforms like `AddBackgroundNoise` have their own `lru_cache_size` parameter. When using a shared cache backend, you can set this to `0` to avoid double caching:
-
-```python
-transform = AddBackgroundNoise(
-    sounds_path=noise_dir,
-    lru_cache_size=0,  # Rely on shared backend only
-    p=1.0
-)
-```
-
-Without this, audio would be cached twice: once in the shared backend, and again in each transform's per-instance LRU cache.
-
-## Benchmark
-
-With 20 noise files (48kHz → 44.1kHz resampling) and 200 Ray tasks:
-
-```
-Without cache: 5.61s
-With cache:    0.35s
-Speedup:       16.2x
-
-Cache: 20 files, 101 MB, 71.5% hit rate
-```
+- **LRU eviction**: When memory limit is reached, least recently used items are evicted.
+- **No pre-loading**: Workers start immediately; cache warms up during processing.
 
 ## Backend Interface
 

--- a/docs/guides/shared_audio_cache.md
+++ b/docs/guides/shared_audio_cache.md
@@ -1,0 +1,116 @@
+# Audio Cache Backend
+
+Transforms like `AddBackgroundNoise` and `ApplyImpulseResponse` load audio files from disk and resample them on each use. Each transform has an LRU cache to avoid redundant loads within a single process.
+
+However, when processing large datasets with parallel workers, each worker starts with an empty cache. If you have `N` workers processing 10,000 audio files, the same impulse responses and background noises get loaded and resampled `N` times instead of once.
+
+The audio cache backend solves this by providing a shared mutable cache across workers. The example below uses Ray, which allows workers to share a cache actor. The cache populates on-demand as files are loaded (no pre-loading required) and uses LRU eviction when the memory limit is reached.
+
+## Usage with Ray
+
+```python
+import numpy as np
+import ray
+from audiomentations import AddBackgroundNoise, set_audio_cache_backend
+
+@ray.remote
+class AudioCacheActor:
+    """Shared mutable cache with LRU eviction."""
+    
+    def __init__(self, max_memory_mb: float = 1000):
+        self.cache = {}
+        self.max_bytes = int(max_memory_mb * 1024 * 1024)
+        self.order = []  # LRU order
+    
+    def get(self, key: tuple) -> np.ndarray | None:
+        if key in self.cache:
+            self.order.remove(key)
+            self.order.append(key)
+            return self.cache[key]
+        return None
+    
+    def put(self, key: tuple, audio: np.ndarray) -> None:
+        if key in self.cache:
+            return
+        # Evict LRU until we have room
+        while self._used() + audio.nbytes > self.max_bytes and self.order:
+            del self.cache[self.order.pop(0)]
+        self.cache[key] = audio
+        self.order.append(key)
+    
+    def _used(self) -> int:
+        return sum(v.nbytes for v in self.cache.values())
+
+
+class RayAudioCacheBackend:
+    """Wrapper that adapts the Actor to the audiomentations interface."""
+    
+    def __init__(self, actor):
+        self.actor = actor
+    
+    def get(self, key: tuple) -> np.ndarray | None:
+        return ray.get(self.actor.get.remote(key))
+    
+    def put(self, key: tuple, audio: np.ndarray) -> None:
+        self.actor.put.remote(key, audio)  # fire-and-forget
+
+
+# Usage
+ray.init()
+cache_actor = AudioCacheActor.remote(max_memory_mb=500)
+
+@ray.remote
+def process_audio(audio, noise_dir, cache_actor):
+    set_audio_cache_backend(RayAudioCacheBackend(cache_actor))
+    transform = AddBackgroundNoise(sounds_path=noise_dir, p=1.0)
+    return transform(audio, sample_rate=44100)
+
+futures = [process_audio.remote(audio, noise_dir, cache_actor) for audio in audio_list]
+results = ray.get(futures)
+```
+
+## Cache Key Format
+
+```python
+cache_key = (file_path, sample_rate, mono)
+```
+
+All three must match for a cache hit.
+
+## Cache Behavior
+
+- **Mutable**: Cache populates on-demand as files are loaded (miss → load full file → cache → slice)
+- **LRU eviction**: When memory limit is reached, least recently used items are evicted
+- **No pre-loading**: Workers start immediately; cache warms up during processing
+
+## Benchmark
+
+With 20 noise files (48kHz → 44.1kHz resampling) and 200 Ray tasks:
+
+```
+Without cache: 5.61s
+With cache:    0.35s
+Speedup:       16.2x
+
+Cache: 20 files, 101 MB, 71.5% hit rate
+```
+
+## Backend Interface
+
+Any object with these methods works:
+
+```python
+class CacheBackend:
+    def get(self, key: tuple) -> np.ndarray | None: ...
+    def put(self, key: tuple, audio: np.ndarray) -> None: ...
+```
+
+## API
+
+```python
+from audiomentations import (
+    set_audio_cache_backend,
+    get_audio_cache_backend,
+    clear_audio_cache_backend,
+)
+```

--- a/tests/test_shared_audio_cache.py
+++ b/tests/test_shared_audio_cache.py
@@ -1,0 +1,360 @@
+"""
+Tests for the audio cache backend feature in audio_loading_utils.
+
+The cache backend allows a mutable cache with get/put interface to be used
+by load_sound_file(). This is useful for sharing audio across multiprocessing
+workers (e.g., with a Ray Actor) to avoid redundant I/O and resampling.
+"""
+import os
+import numpy as np
+import pytest
+
+from audiomentations.core.audio_loading_utils import (
+    load_sound_file,
+    set_audio_cache_backend,
+    get_audio_cache_backend,
+    clear_audio_cache_backend,
+)
+from demo.demo import DEMO_DIR
+
+
+class DictCacheBackend:
+    """Simple dict-based cache backend for testing."""
+    
+    def __init__(self, initial_cache=None):
+        self.cache = initial_cache or {}
+        self.gets = 0
+        self.puts = 0
+    
+    def get(self, key):
+        self.gets += 1
+        return self.cache.get(key)
+    
+    def put(self, key, audio):
+        self.puts += 1
+        self.cache[key] = audio
+
+
+class TestAudioCacheBackendBasics:
+    """Test basic cache backend get/set/clear operations."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_audio_cache_backend()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        clear_audio_cache_backend()
+
+    def test_cache_is_none_by_default(self):
+        """Cache backend should be None when not set."""
+        assert get_audio_cache_backend() is None
+
+    def test_set_and_get_backend(self):
+        """Setting backend should make it retrievable."""
+        backend = DictCacheBackend()
+        set_audio_cache_backend(backend)
+        assert get_audio_cache_backend() is backend
+
+    def test_clear_backend(self):
+        """Clearing backend should set it to None."""
+        backend = DictCacheBackend()
+        set_audio_cache_backend(backend)
+        clear_audio_cache_backend()
+        assert get_audio_cache_backend() is None
+
+    def test_set_backend_to_none(self):
+        """Setting backend to None should disable it."""
+        backend = DictCacheBackend()
+        set_audio_cache_backend(backend)
+        set_audio_cache_backend(None)
+        assert get_audio_cache_backend() is None
+
+
+class TestAudioCacheBackendWithLoadSoundFile:
+    """Test that load_sound_file() correctly uses the cache backend."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_audio_cache_backend()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        clear_audio_cache_backend()
+
+    def test_cache_miss_loads_from_disk_and_caches(self):
+        """When file is not in cache, should load from disk and cache it."""
+        backend = DictCacheBackend()
+        set_audio_cache_backend(backend)
+
+        file_path = os.path.join(DEMO_DIR, "acoustic_guitar_0.wav")
+        samples, sample_rate = load_sound_file(file_path, sample_rate=16000)
+
+        assert sample_rate == 16000
+        assert samples.dtype == np.float32
+        assert samples.ndim == 1
+        assert len(samples) > 0
+        
+        # Should have called get (miss) and put
+        assert backend.gets == 1
+        assert backend.puts == 1
+        
+        # Cache should now contain the file
+        cache_key = (file_path, 16000, True)
+        assert cache_key in backend.cache
+
+    def test_cache_hit_returns_cached_data_mono(self):
+        """When file is in cache, should return cached data without loading."""
+        file_path = os.path.join(DEMO_DIR, "acoustic_guitar_0.wav")
+        sample_rate = 16000
+
+        # Create cache with fake audio
+        cached_audio = np.ones(1000, dtype=np.float32) * 0.5
+        cache_key = (file_path, sample_rate, True)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Load - should return cached data
+        samples, returned_sr = load_sound_file(file_path, sample_rate=sample_rate, mono=True)
+
+        assert returned_sr == sample_rate
+        assert samples.dtype == np.float32
+        assert samples.ndim == 1
+        assert len(samples) == 1000
+        assert np.allclose(samples, 0.5)
+        
+        # Should have called get (hit) but not put
+        assert backend.gets == 1
+        assert backend.puts == 0
+
+    def test_cache_hit_returns_cached_data_stereo(self):
+        """When file is in cache with mono=False, should return stereo cached data."""
+        file_path = os.path.join(DEMO_DIR, "stereo_16bit.wav")
+        sample_rate = 16000
+
+        # Create fake cached stereo audio
+        cached_audio = np.ones((2, 500), dtype=np.float32) * 0.25
+        cache_key = (file_path, sample_rate, False)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Load - should return cached stereo data
+        samples, returned_sr = load_sound_file(file_path, sample_rate=sample_rate, mono=False)
+
+        assert returned_sr == sample_rate
+        assert samples.dtype == np.float32
+        assert samples.ndim == 2
+        assert samples.shape == (2, 500)
+        assert np.allclose(samples, 0.25)
+
+    def test_sample_rate_mismatch_causes_cache_miss(self):
+        """Cache key includes sample_rate, so mismatched rate should miss."""
+        file_path = os.path.join(DEMO_DIR, "acoustic_guitar_0.wav")
+
+        # Cache at 44100 Hz
+        cached_audio = np.ones(1000, dtype=np.float32) * 0.5
+        cache_key = (file_path, 44100, True)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Request at 16000 Hz - should miss cache and load from disk
+        samples, returned_sr = load_sound_file(file_path, sample_rate=16000, mono=True)
+
+        assert returned_sr == 16000
+        # Should NOT be our cached data (which was all 0.5)
+        assert not np.allclose(samples, 0.5)
+        # Should have cached at 16000 Hz
+        assert (file_path, 16000, True) in backend.cache
+
+    def test_mono_mismatch_causes_cache_miss(self):
+        """Cache key includes mono flag, so mismatched mono should miss."""
+        file_path = os.path.join(DEMO_DIR, "stereo_16bit.wav")
+        sample_rate = 16000
+
+        # Cache as mono
+        cached_audio = np.ones(1000, dtype=np.float32) * 0.5
+        cache_key = (file_path, sample_rate, True)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Request as stereo - should miss cache and load from disk
+        samples, returned_sr = load_sound_file(file_path, sample_rate=sample_rate, mono=False)
+
+        assert returned_sr == sample_rate
+        # Should be stereo from disk, not our mono cached data
+        assert samples.ndim == 2
+
+    def test_cache_returns_copy_not_reference(self):
+        """Cached data should be copied to prevent mutation."""
+        file_path = "/fake/path.wav"
+        sample_rate = 44100
+
+        original_cached = np.ones(100, dtype=np.float32)
+        cache_key = (file_path, sample_rate, True)
+        backend = DictCacheBackend({cache_key: original_cached})
+        set_audio_cache_backend(backend)
+
+        # Get from cache
+        samples, _ = load_sound_file(file_path, sample_rate=sample_rate, mono=True)
+
+        # Mutate the returned samples
+        samples[:] = 999.0
+
+        # Original cache should be unchanged
+        assert np.allclose(original_cached, 1.0)
+
+    def test_offset_slicing_mono(self):
+        """Offset parameter should slice cached mono audio correctly."""
+        file_path = "/fake/path.wav"
+        sample_rate = 1000  # 1000 samples/sec for easy math
+
+        # 2 seconds of audio
+        cached_audio = np.arange(2000, dtype=np.float32)
+        cache_key = (file_path, sample_rate, True)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Request with 0.5 second offset
+        samples, _ = load_sound_file(file_path, sample_rate=sample_rate, mono=True, offset=0.5)
+
+        # Should start at sample 500
+        assert samples[0] == 500.0
+        assert len(samples) == 1500  # remaining samples
+
+    def test_duration_slicing_mono(self):
+        """Duration parameter should slice cached mono audio correctly."""
+        file_path = "/fake/path.wav"
+        sample_rate = 1000
+
+        # 2 seconds of audio
+        cached_audio = np.arange(2000, dtype=np.float32)
+        cache_key = (file_path, sample_rate, True)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Request 0.5 seconds starting from offset 0.2
+        samples, _ = load_sound_file(
+            file_path, sample_rate=sample_rate, mono=True, offset=0.2, duration=0.5
+        )
+
+        # Should be samples 200-700
+        assert len(samples) == 500
+        assert samples[0] == 200.0
+        assert samples[-1] == 699.0
+
+    def test_offset_slicing_stereo(self):
+        """Offset parameter should slice cached stereo audio correctly."""
+        file_path = "/fake/path.wav"
+        sample_rate = 1000
+
+        # 2 seconds of stereo audio
+        cached_audio = np.stack([
+            np.arange(2000, dtype=np.float32),
+            np.arange(2000, dtype=np.float32) + 10000,
+        ])
+        cache_key = (file_path, sample_rate, False)
+        backend = DictCacheBackend({cache_key: cached_audio})
+        set_audio_cache_backend(backend)
+
+        # Request with 0.3 second offset
+        samples, _ = load_sound_file(file_path, sample_rate=sample_rate, mono=False, offset=0.3)
+
+        # Should be shape (2, 1700)
+        assert samples.shape == (2, 1700)
+        assert samples[0, 0] == 300.0
+        assert samples[1, 0] == 10300.0
+
+    def test_no_cache_set_loads_from_disk(self):
+        """When no cache is set, should load normally from disk."""
+        # Ensure cache is None
+        clear_audio_cache_backend()
+
+        file_path = os.path.join(DEMO_DIR, "acoustic_guitar_0.wav")
+        samples, sample_rate = load_sound_file(file_path, sample_rate=None)
+
+        assert sample_rate == 16000
+        assert samples.dtype == np.float32
+        assert len(samples) == 140544
+
+    def test_cache_miss_with_offset_caches_full_file(self):
+        """When loading with offset, should cache the FULL file, not the slice."""
+        backend = DictCacheBackend()
+        set_audio_cache_backend(backend)
+
+        file_path = os.path.join(DEMO_DIR, "acoustic_guitar_0.wav")
+        sample_rate = 16000
+        
+        # Load with offset
+        samples, _ = load_sound_file(file_path, sample_rate=sample_rate, offset=1.0, duration=1.0)
+        
+        # Cached version should be the full file
+        cache_key = (file_path, sample_rate, True)
+        cached = backend.cache[cache_key]
+        
+        # Full file is longer than 2 seconds
+        assert len(cached) > len(samples)
+        assert len(cached) == 140544  # Full file length at 16kHz
+
+
+class TestAudioCacheBackendWithTransforms:
+    """Test that transforms work correctly with the cache backend."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_audio_cache_backend()
+
+    def teardown_method(self):
+        """Clear cache after each test."""
+        clear_audio_cache_backend()
+
+    def test_apply_impulse_response_with_cache(self):
+        """ApplyImpulseResponse should work with cached impulse responses."""
+        from audiomentations import ApplyImpulseResponse
+
+        ir_dir = os.path.join(DEMO_DIR, "ir")
+        sample_rate = 16000
+
+        # Pre-load IRs into cache
+        cache = {}
+        ir_file = os.path.join(ir_dir, "impulse_response_0.wav")
+        mono_ir, _ = load_sound_file(ir_file, sample_rate=sample_rate, mono=True)
+        stereo_ir, _ = load_sound_file(ir_file, sample_rate=sample_rate, mono=False)
+        cache[(ir_file, sample_rate, True)] = mono_ir
+        cache[(ir_file, sample_rate, False)] = stereo_ir
+
+        backend = DictCacheBackend(cache)
+        set_audio_cache_backend(backend)
+
+        # Create transform and apply
+        transform = ApplyImpulseResponse(ir_path=ir_dir, p=1.0)
+        input_audio = np.random.randn(1024).astype(np.float32)
+
+        output = transform(input_audio, sample_rate=sample_rate)
+
+        assert output.dtype == np.float32
+        assert output.shape == input_audio.shape
+
+    def test_add_background_noise_with_cache(self):
+        """AddBackgroundNoise should work with cached noise files."""
+        from audiomentations import AddBackgroundNoise
+
+        noise_dir = os.path.join(DEMO_DIR, "background_noises")
+        sample_rate = 16000
+
+        # Pre-load noise into cache
+        cache = {}
+        noise_file = os.path.join(noise_dir, "hens.ogg")
+        noise_audio, _ = load_sound_file(noise_file, sample_rate=sample_rate, mono=True)
+        cache[(noise_file, sample_rate, True)] = noise_audio
+
+        backend = DictCacheBackend(cache)
+        set_audio_cache_backend(backend)
+
+        # Create transform and apply
+        transform = AddBackgroundNoise(sounds_path=noise_dir, p=1.0)
+        input_audio = np.random.randn(8000).astype(np.float32)
+
+        output = transform(input_audio, sample_rate=sample_rate)
+
+        assert output.dtype == np.float32
+        assert output.shape == input_audio.shape


### PR DESCRIPTION
## Summary

Adds a pluggable cache backend interface to `load_sound_file()` that enables sharing loaded/resampled audio across parallel workers. This eliminates redundant disk I/O and resampling when processing large datasets with frameworks like Ray.

I provide a small guide that shows how to make an LRU cache with configurable memory size using Ray, but note that no dependency for Ray is needed for `audiomentations`, and that other object stores are usable as well.

## Motivation

Transforms like `AddBackgroundNoise` and `ApplyImpulseResponse` load audio files from disk and resample them on each use. In multiprocessing each worker would load and resample these files individually, slowing down the job since each worker may be duplicating effort and memory.

## Solution

A simple cache backend interface with `get(key)` and `put(key, audio)` methods:

```python
from audiomentations import set_audio_cache_backend

class MyCacheBackend:
    def get(self, key): ...  # Returns np.ndarray or None
    def put(self, key, audio): ...

set_audio_cache_backend(MyCacheBackend())
```

Key format: `(file_path, sample_rate, mono)`

## Key behaviors

Cache miss: Loads full file, caches it, then slices if needed for offset/duration
Cache hit: Returns copy from cache, slices if needed

No audiomentations dependencies: Backend implementation is user-provided (can be Ray Actor, Redis, dict, etc.)

## Changes

- `audiomentations/core/audio_loading_utils.py`: Added set_audio_cache_backend(), get_audio_cache_backend(), clear_audio_cache_backend()
- `audiomentations/__init__.py`: Export new functions
- `tests/test_shared_audio_cache.py`: Tests covering cache hit/miss, slicing, transforms
- `docs/guides/shared_audio_cache.md`: Usage guide with Ray Actor example
